### PR TITLE
Update singlefile example

### DIFF
--- a/examples/singlefile/README.md
+++ b/examples/singlefile/README.md
@@ -1,14 +1,13 @@
 # An single-file example RESTful API app showcasing the power of pyramid_openapi3
 
-The `app.py` file in this folder showcases how to use the [pyramid_openapi3](https://github.com/niteoweb/pyramid_openapi3) Pyramid add-on for building robust RESTful APIs. With only a few lines of code you get automatic validation of requests and responses against an OpenAPI v3 schema, along with Swagger "try-it-out" documentation for your API.
+The `app.py` file in this folder showcases how to use the [pyramid_openapi3](https://github.com/Pylons/pyramid_openapi3) Pyramid add-on for building robust RESTful APIs. With only a few lines of code you get automatic validation of requests and responses against an OpenAPI v3 schema, along with Swagger "try-it-out" documentation for your API.
 
 ## How to run
 
 ```bash
-* git clone https://github.com/niteoweb/pyramid_openapi3.git
-* cd pyramid_openapi3/examples/singlefile
-* virtualenv -p python3.7 .
-* source bin/activate
+* mkdir my-openapi
+* cd my-openapi
+* wget https://raw.githubusercontent.com/Pylons/pyramid_openapi3/master/examples/singlefile/app.py
 * pip install pyramid_openapi3
 * python app.py
 ```
@@ -25,9 +24,9 @@ All of these examples are covered with tests that you can run with `$ python -m 
 
 ## Further read
 
-* A slightly more complex, multi-file example is available in the [`examples/todoapp`](https://github.com/niteoweb/pyramid_openapi3/tree/master/examples/todoapp) folder.
+* A slightly more complex, multi-file example is available in the [`examples/todoapp`](https://github.com/Pylons/pyramid_openapi3/tree/master/examples/todoapp) folder.
 
-* More information about the library providing the integration between OpenAPI specs and Pyramid, more advanced features and design defence, is available in the main [README](https://github.com/niteoweb/pyramid_openapi3) file.
+* More information about the library providing the integration between OpenAPI specs and Pyramid, more advanced features and design defence, is available in the main [README](https://github.com/Pylons/pyramid_openapi3) file.
 
 * More validators for fields are listed in the [OpenAPI Specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#properties) document. You can use Regex as well.
 

--- a/examples/singlefile/app.py
+++ b/examples/singlefile/app.py
@@ -1,10 +1,9 @@
 """A single-file demo of pyramid_openapi3.
 
 Usage:
-* git clone https://github.com/niteoweb/pyramid_openapi3.git
-* cd pyramid_openapi3/examples/singlefile
-* virtualenv -p python3.7 .
-* source bin/activate
+* mkdir my-openapi
+* cd my-openapi
+* wget https://raw.githubusercontent.com/Pylons/pyramid_openapi3/master/examples/singlefile/app.py
 * pip install pyramid_openapi3
 * python app.py
 """


### PR DESCRIPTION
Update repository in singlefile examples and modify the "How to run"
instructions. You don't need to clone the repository in order to try
out pyramid_openapi3. It is only confusing to beginers so we can remove
it.