### PR TITLE
fix parameters in header and cookie

### DIFF
--- a/pyramid_openapi3/tests/test_views.py
+++ b/pyramid_openapi3/tests/test_views.py
@@ -244,3 +244,119 @@ def test_openapi_view_validate_HTTPExceptions() -> None:
             view(context, request)
 
         assert str(exc.value) == "Unknown response http status: 403"
+
+
+def test_header_parameters() -> None:
+    """Test parameters in header are validated correctly."""
+    with testConfig() as config:
+        config.include("pyramid_openapi3")
+        with tempfile.NamedTemporaryFile() as document:
+            document.write(
+                b'openapi: "3.0.0"\n'
+                b"info:\n"
+                b'  version: "1.0.0"\n'
+                b"  title: Foo API\n"
+                b"paths:\n"
+                b"  /foo:\n"
+                b"    get:\n"
+                b"      parameters:\n"
+                b"        - name: foo\n"
+                b"          in: header\n"
+                b"          required: true\n"
+                b"          schema:\n"
+                b"            type: integer\n"
+                b"      responses:\n"
+                b"        200:\n"
+                b"          description: A foo\n"
+            )
+            document.seek(0)
+
+            config.pyramid_openapi3_spec(
+                document.name, route="/foo.yaml", route_name="foo_api_spec"
+            )
+
+        config.add_route("foo", "/foo")
+        view_func = lambda *arg: "foo"  # noqa: E731  # pragma: no branch
+        config.add_view(openapi=True, renderer="json", view=view_func, route_name="foo")
+
+        validation_view = lambda *arg: "validation error"  # noqa: E731
+        config.add_view(view=validation_view, name="validation_view", renderer="json")
+        config.pyramid_openapi3_validation_error_view("validation_view")
+
+        request_interface = config.registry.queryUtility(IRouteRequest, name="foo")
+        view = config.registry.adapters.registered(
+            (IViewClassifier, request_interface, Interface), IView, name=""
+        )
+        # Test validation fails
+        request = DummyRequest(config=config)
+        request.matched_route = DummyRoute(name="foo", pattern="/foo")
+        context = None
+        response = view(context, request)
+
+        assert response.json == "validation error"
+
+        # Test validation succeeds
+        request = DummyRequest(config=config, headers={"foo": "1"})
+        request.matched_route = DummyRoute(name="foo", pattern="/foo")
+        context = None
+        response = view(context, request)
+
+        assert response.json == "foo"
+
+
+def test_cookie_parameters() -> None:
+    """Test parameters in cookie are validated correctly."""
+    with testConfig() as config:
+        config.include("pyramid_openapi3")
+        with tempfile.NamedTemporaryFile() as document:
+            document.write(
+                b'openapi: "3.0.0"\n'
+                b"info:\n"
+                b'  version: "1.0.0"\n'
+                b"  title: Foo API\n"
+                b"paths:\n"
+                b"  /foo:\n"
+                b"    get:\n"
+                b"      parameters:\n"
+                b"        - name: foo\n"
+                b"          in: cookie\n"
+                b"          required: true\n"
+                b"          schema:\n"
+                b"            type: integer\n"
+                b"      responses:\n"
+                b"        200:\n"
+                b"          description: A foo\n"
+            )
+            document.seek(0)
+
+            config.pyramid_openapi3_spec(
+                document.name, route="/foo.yaml", route_name="foo_api_spec"
+            )
+
+        config.add_route("foo", "/foo")
+        view_func = lambda *arg: "foo"  # noqa: E731  # pragma: no branch
+        config.add_view(openapi=True, renderer="json", view=view_func, route_name="foo")
+
+        validation_view = lambda *arg: "validation error"  # noqa: E731
+        config.add_view(view=validation_view, name="validation_view", renderer="json")
+        config.pyramid_openapi3_validation_error_view("validation_view")
+
+        request_interface = config.registry.queryUtility(IRouteRequest, name="foo")
+        view = config.registry.adapters.registered(
+            (IViewClassifier, request_interface, Interface), IView, name=""
+        )
+        # Test validation fails
+        request = DummyRequest(config=config)
+        request.matched_route = DummyRoute(name="foo", pattern="/foo")
+        context = None
+        response = view(context, request)
+
+        assert response.json == "validation error"
+
+        # Test validation succeeds
+        request = DummyRequest(config=config, cookies={"foo": "1"})
+        request.matched_route = DummyRoute(name="foo", pattern="/foo")
+        context = None
+        response = view(context, request)
+
+        assert response.json == "foo"

--- a/pyramid_openapi3/tests/test_wrappers.py
+++ b/pyramid_openapi3/tests/test_wrappers.py
@@ -36,8 +36,8 @@ def test_mapped_values_request() -> None:
     assert openapi_request.body == ""
     assert openapi_request.mimetype == "text/html"
     assert openapi_request.parameters == {
-        "cookies": {"tasty-foo": "tasty-bar"},
-        "headers": {"X-Foo": "Bar"},
+        "cookie": {"tasty-foo": "tasty-bar"},
+        "header": {"X-Foo": "Bar"},
         "path": {"foo": "bar"},
         "query": {},
     }

--- a/pyramid_openapi3/wrappers.py
+++ b/pyramid_openapi3/wrappers.py
@@ -41,8 +41,8 @@ class PyramidOpenAPIRequest(BaseOpenAPIRequest):
         return {
             "path": self.request.matchdict,
             "query": self.request.GET,
-            "headers": self.request.headers,
-            "cookies": self.request.cookies,
+            "header": self.request.headers,
+            "cookie": self.request.cookies,
         }
 
     @property


### PR DESCRIPTION
parameters `in: header` and `in: cookie` validation failed because parameter location did not match with keys in parameter dictionary created in request wrapper class.