### PR TITLE
Validate all endpoints are handled

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -17,6 +17,4 @@ ignore =
 # W503: line break before binary operator
     W503,
 # E501: line too long (85 > 79 characters) - use B950 instead (10% leeway)
-    E501,
-#D401 First line should be in imperative mood
-    D401
+    E501

--- a/.flake8
+++ b/.flake8
@@ -17,4 +17,6 @@ ignore =
 # W503: line break before binary operator
     W503,
 # E501: line too long (85 > 79 characters) - use B950 instead (10% leeway)
-    E501
+    E501,
+#D401 First line should be in imperative mood
+    D401

--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -1,5 +1,4 @@
 """Configure pyramid_openapi3 addon."""
-
 from .exceptions import MissingEndpointsError
 from .exceptions import RequestValidationError
 from .wrappers import PyramidOpenAPIRequest
@@ -21,6 +20,7 @@ from pyramid.tweens import EXCVIEW
 from string import Template
 
 import typing as t
+import warnings
 
 
 def includeme(config: Configurator) -> None:
@@ -163,11 +163,16 @@ def check_all_routes(event: ApplicationCreated):
     app = event.app
     openapi_settings = app.registry.settings.get("pyramid_openapi3")
     if not openapi_settings:
-        return  # pyramid_openapi3 not configured?
+        # pyramid_openapi3 not configured?
+        warnings.warn(
+            "pyramid_openapi3 settings not found. "
+            "Did you forget to call config.pyramid_openapi3_spec?"
+        )
+        return
 
     paths = list(openapi_settings["spec"].paths.keys())
     routes = [route.path for name, route in app.routes_mapper.routes.items()]
 
     missing = [r for r in paths if r not in routes]
-    if len(missing):
+    if missing:
         raise MissingEndpointsError(missing)

--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -154,7 +154,7 @@ def add_spec_view(
 
 
 def check_all_routes(event: ApplicationCreated):
-    """Asserts all routes in the spec are defined on the app.
+    """Assert all routes in the spec are defined on the app.
 
     This handler method that listens for ApplicationCreated event and asserts
     all routes defined on the spec have been registered

--- a/pyramid_openapi3/exceptions.py
+++ b/pyramid_openapi3/exceptions.py
@@ -37,3 +37,12 @@ class ResponseValidationError(HTTPInternalServerError):
 
     def _json_formatter(self, status, body, title, environ) -> t.Dict:
         return {"message": body, "code": status, "title": self.title}
+
+
+class MissingEndpointsError(Exception):
+    missing: list
+
+    def __init__(self, missing):
+        self.missing = missing
+        message = f"Unable to find registered " f"routes or endpoints {missing}"
+        super(MissingEndpointsError, self).__init__(message)

--- a/pyramid_openapi3/tests/test_app_construction.py
+++ b/pyramid_openapi3/tests/test_app_construction.py
@@ -100,4 +100,5 @@ def test_unconfigured_app(simple_config):
         foo_view, route_name="foo", renderer="string", request_method="OPTIONS"
     )
 
-    simple_config.make_wsgi_app()
+    with pytest.warns(UserWarning, match="pyramid_openapi3 settings not found"):
+        simple_config.make_wsgi_app()

--- a/pyramid_openapi3/tests/test_app_construction.py
+++ b/pyramid_openapi3/tests/test_app_construction.py
@@ -38,7 +38,7 @@ def bar_view(request):
     return "Bar"  # pragma: no cover
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def document():
     """Simple fixture to load the DOCUMENT into a temp file."""
     with tempfile.NamedTemporaryFile() as document:
@@ -48,7 +48,7 @@ def document():
         yield document
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def simple_config():
     """Simple app config fixture."""
     with testConfig() as config:
@@ -57,7 +57,7 @@ def simple_config():
         yield config
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture
 def app_config(simple_config, document):
     """Incremented fixture that loads the DOCUMENT above into the config."""
     simple_config.pyramid_openapi3_spec(

--- a/pyramid_openapi3/tests/test_app_construction.py
+++ b/pyramid_openapi3/tests/test_app_construction.py
@@ -1,0 +1,81 @@
+"""Tests for app creation when using pyramid_openapi3."""
+from pyramid.testing import testConfig
+from pyramid_openapi3 import MissingEndpointsError
+
+import pytest
+import tempfile
+
+DOCUMENT = b"""
+    openapi: "3.0.0"
+    info:
+      version: "1.0.0"
+      title: Foo API
+    paths:
+      /foo:
+        get:
+          responses:
+            200:
+              description: A foo
+        post:
+          responses:
+            200:
+              description: A POST foo
+      /bar:
+        get:
+          responses:
+            200:
+              description: A bar
+"""
+
+
+def foo_view(request):
+    """Dummy view method."""
+    return "Foo"
+
+
+def bar_view(request):
+    """Dummy view method."""
+    return "Bar"
+
+
+@pytest.fixture
+def app_config():
+    """Simple fixture that loads a config using DOCUMENT above."""
+    with tempfile.NamedTemporaryFile() as document, testConfig() as config:
+
+        config.include("pyramid_openapi3")
+
+        document.write(DOCUMENT)
+        document.seek(0)
+
+        config.pyramid_openapi3_spec(
+            document.name, route="/foo.yaml", route_name="foo_api_spec"
+        )
+        yield config
+
+
+def test_all_routes(app_config):
+    """Test case showing that an app can be created with all routes define."""
+    app_config.add_route(name="foo", pattern="/foo")
+    app_config.add_route(name="bar", pattern="/bar")
+    app_config.add_view(
+        foo_view, route_name="foo", renderer="string", request_method="OPTIONS"
+    )
+    app_config.add_view(
+        bar_view, route_name="bar", renderer="string", request_method="GET"
+    )
+
+    app_config.make_wsgi_app()
+
+
+def test_missing_routes(app_config):
+    """Test case showing app creation fails, when define routes are missing."""
+    app_config.add_route(name="foo", pattern="/foo")
+    app_config.add_view(
+        foo_view, route_name="foo", renderer="string", request_method="GET"
+    )
+
+    with pytest.raises(MissingEndpointsError) as ex:
+        app_config.make_wsgi_app()
+
+    assert "/bar" in ex.value.missing

--- a/pyramid_openapi3/tests/test_app_construction.py
+++ b/pyramid_openapi3/tests/test_app_construction.py
@@ -29,18 +29,18 @@ DOCUMENT = b"""
 
 
 def foo_view(request):
-    """Dummy view method."""
+    """Return a dummy string."""
     return "Foo"  # pragma: no cover
 
 
 def bar_view(request):
-    """Dummy view method."""
+    """Return a dummy string."""
     return "Bar"  # pragma: no cover
 
 
 @pytest.fixture
 def document():
-    """Simple fixture to load the DOCUMENT into a temp file."""
+    """Load the DOCUMENT into a temp file."""
     with tempfile.NamedTemporaryFile() as document:
         document.write(DOCUMENT)
         document.seek(0)
@@ -50,7 +50,7 @@ def document():
 
 @pytest.fixture
 def simple_config():
-    """Simple app config fixture."""
+    """Config fixture."""
     with testConfig() as config:
         config.include("pyramid_openapi3")
 


### PR DESCRIPTION
Proposed changes for #21 

This will listen for an event triggered by Pyramid once all configurations have been parsed and the App has been created.

At this point we're certain no new routes will be added to the config, so we can check whether all the routes in the spec have been registered on the application route map.

Here I raise an exception if any route is missing.