### PR TITLE
Upgrade to openapi-core 0.13.x and register a view to catch and JSONify openapi-related errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,22 @@
 ## Changelog
 
-0.5.0-beta.1 (2020-02-27)
+0.5.0-beta.2 (2020-02-29)
 -------------------------
 
 * Move `openapi_validation_error` from `examples/todoapp` into the main
   package so it becomes a first-class citizen and people can use it without
-  copy/pasting. Enable it with `config.pyramid_openapi3_JSONify_errors()`.
+  copy/pasting. If you need custom JSON rendering, you can provide
+  your own `extract_error` function via `pyramid_openapi3_extract_error`
+  config setting.
   [zupo]
 
 * Upgrade `openapi-core` to `0.13.x` which brings a complete rewrite of the
   validation mechanism that is now based on `jsonschema` library. This
   manifests as different validation error messages.
+
+  [BREAKING CHANGE] By default, `openapi-core` no longer creates models
+  from validated data, but returns `dict`s. More info on
+  https://github.com/p1c2u/openapi-core/issues/205
   [zupo]
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-0.5.0-beta.2 (2020-02-29)
+0.5.0-beta.3 (2020-03-02)
 -------------------------
 
 * Move `openapi_validation_error` from `examples/todoapp` into the main

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Move `openapi_validation_error` from `examples/todoapp` into the main
   package so it becomes a first-class citizen and people can use it without
   copy/pasting. If you need custom JSON rendering, you can provide
-  your own `extract_error` function via `pyramid_openapi3_extract_error`
+  your own `extract_errors` function via `pyramid_openapi3_extract_errors`
   config setting.
   [zupo]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## Changelog
 
+0.5.0-beta.1 (2020-02-27)
+-------------------------
+
+* Move `openapi_validation_error` from `examples/todoapp` into the main
+  package so it becomes a first-class citizen and people can use it without
+  copy/pasting. Enable it with `config.pyramid_openapi3_JSONify_errors()`.
+  [zupo]
+
+* Upgrade `openapi-core` to `0.13.x` which brings a complete rewrite of the
+  validation mechanism that is now based on `jsonschema` library. This
+  manifests as different validation error messages.
+  [zupo]
+
+
 0.4.1 (2019-10-22)
 ------------------
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -23,10 +23,25 @@
         },
         "hupper": {
             "hashes": [
-                "sha256:3b1c2222ec7b8159e7ad059e4493c6cc634c86184af0bf2ce5aba6edd241cf5f",
-                "sha256:5ab839f9428dd2d993092193ad0032f968eae007873916794c3856131b2df112"
+                "sha256:109928477eeac69a55cdba65d20f09d06eff596a861f96c7736028988f090096",
+                "sha256:25e19eab7ba5d25c40c5fa083c845c5919ad2652b4bff002d1e9016b238489ae"
             ],
-            "version": "==1.9.1"
+            "version": "==1.10.1"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302",
+                "sha256:b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==1.5.0"
+        },
+        "isodate": {
+            "hashes": [
+                "sha256:2e364a3d5759479cdb2d37cce6b9376ea504db2ff90252a2e5b7cc89cc9ff2d8",
+                "sha256:aa4d33c06640f5352aca96e4b81afd8ab3b47337cc12089822d6f322ac772c81"
+            ],
+            "version": "==0.6.0"
         },
         "jsonschema": {
             "hashes": [
@@ -63,11 +78,11 @@
         },
         "openapi-core": {
             "hashes": [
-                "sha256:035f66a1380c27d594a2993a92e2ab67fdede48d879e14f6f2c2928f22889876",
-                "sha256:33c73af42e87ed80f150b5ec3184dfad2952f9e326e84c56bc8c88da35a8c6e6",
-                "sha256:4a295685577d5d2edfffe48162b6bc094e3fe1039e51d9134834caa88aa7eb99"
+                "sha256:a6b5558e03f9720cafa386c34ce3c9ff53b491c9c02bdb6dc692879c085726ae",
+                "sha256:dbbec1c0ebf2084efb0cf601af77c1c54d5ddb185dd5b7c3bf3352c8898284df",
+                "sha256:e35b6785882c0627931f75cd9c6c09bc7b196145b6c2e1f7e676420d9004a3b2"
             ],
-            "version": "==0.11.1"
+            "version": "==0.13.2"
         },
         "openapi-spec-validator": {
             "hashes": [
@@ -165,6 +180,20 @@
             ],
             "version": "==1.8.6"
         },
+        "werkzeug": {
+            "hashes": [
+                "sha256:169ba8a33788476292d04186ab33b01d6add475033dfc07215e6d219cc077096",
+                "sha256:6dc65cf9091cf750012f56f2cad759fa9e879f511b5ff8685e456b4e3bf90d16"
+            ],
+            "version": "==1.0.0"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:12248a63bbdf7548f89cb4c7cda4681e537031eda29c02ea29674bc6854460c2",
+                "sha256:7c0f8e91abc0dc07a5068f315c52cb30c66bfbc581e5b50704c8a2f6ebae794a"
+            ],
+            "version": "==3.0.0"
+        },
         "zope.deprecation": {
             "hashes": [
                 "sha256:0d453338f04bacf91bbfba545d8bcdf529aa829e67b705eac8c1a7fdce66e2df",
@@ -225,13 +254,6 @@
             ],
             "version": "==1.4.3"
         },
-        "aspy.yaml": {
-            "hashes": [
-                "sha256:463372c043f70160a9ec950c3f1e4c3a82db5fca01d334b6bc89c7164d744bdc",
-                "sha256:e7c742382eff2caed61f87a39d13f99109088e5e93f04d76eb8d4b28aa143f45"
-            ],
-            "version": "==1.3.0"
-        },
         "attrs": {
             "hashes": [
                 "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
@@ -257,10 +279,10 @@
         },
         "bleach": {
             "hashes": [
-                "sha256:213336e49e102af26d9cde77dd2d0397afabc5a6bf2fed985dc35b5d1e285a16",
-                "sha256:3fdf7f77adcf649c9911387df51254b813185e32b2c6619f690b593a617e19fa"
+                "sha256:44f69771e2ac81ff30d929d485b7f9919f3ad6d019b6b20c74f3b8687c3f70df",
+                "sha256:aa8b870d0f46965bac2c073a93444636b0e1ca74e9777e34f03dd494b8a59d48"
             ],
-            "version": "==3.1.0"
+            "version": "==3.1.1"
         },
         "certifi": {
             "hashes": [
@@ -269,50 +291,12 @@
             ],
             "version": "==2019.11.28"
         },
-        "cffi": {
-            "hashes": [
-                "sha256:0b49274afc941c626b605fb59b59c3485c17dc776dc3cc7cc14aca74cc19cc42",
-                "sha256:0e3ea92942cb1168e38c05c1d56b0527ce31f1a370f6117f1d490b8dcd6b3a04",
-                "sha256:135f69aecbf4517d5b3d6429207b2dff49c876be724ac0c8bf8e1ea99df3d7e5",
-                "sha256:19db0cdd6e516f13329cba4903368bff9bb5a9331d3410b1b448daaadc495e54",
-                "sha256:2781e9ad0e9d47173c0093321bb5435a9dfae0ed6a762aabafa13108f5f7b2ba",
-                "sha256:291f7c42e21d72144bb1c1b2e825ec60f46d0a7468f5346841860454c7aa8f57",
-                "sha256:2c5e309ec482556397cb21ede0350c5e82f0eb2621de04b2633588d118da4396",
-                "sha256:2e9c80a8c3344a92cb04661115898a9129c074f7ab82011ef4b612f645939f12",
-                "sha256:32a262e2b90ffcfdd97c7a5e24a6012a43c61f1f5a57789ad80af1d26c6acd97",
-                "sha256:3c9fff570f13480b201e9ab69453108f6d98244a7f495e91b6c654a47486ba43",
-                "sha256:415bdc7ca8c1c634a6d7163d43fb0ea885a07e9618a64bda407e04b04333b7db",
-                "sha256:42194f54c11abc8583417a7cf4eaff544ce0de8187abaf5d29029c91b1725ad3",
-                "sha256:4424e42199e86b21fc4db83bd76909a6fc2a2aefb352cb5414833c030f6ed71b",
-                "sha256:4a43c91840bda5f55249413037b7a9b79c90b1184ed504883b72c4df70778579",
-                "sha256:599a1e8ff057ac530c9ad1778293c665cb81a791421f46922d80a86473c13346",
-                "sha256:5c4fae4e9cdd18c82ba3a134be256e98dc0596af1e7285a3d2602c97dcfa5159",
-                "sha256:5ecfa867dea6fabe2a58f03ac9186ea64da1386af2159196da51c4904e11d652",
-                "sha256:62f2578358d3a92e4ab2d830cd1c2049c9c0d0e6d3c58322993cc341bdeac22e",
-                "sha256:6471a82d5abea994e38d2c2abc77164b4f7fbaaf80261cb98394d5793f11b12a",
-                "sha256:6d4f18483d040e18546108eb13b1dfa1000a089bcf8529e30346116ea6240506",
-                "sha256:71a608532ab3bd26223c8d841dde43f3516aa5d2bf37b50ac410bb5e99053e8f",
-                "sha256:74a1d8c85fb6ff0b30fbfa8ad0ac23cd601a138f7509dc617ebc65ef305bb98d",
-                "sha256:7b93a885bb13073afb0aa73ad82059a4c41f4b7d8eb8368980448b52d4c7dc2c",
-                "sha256:7d4751da932caaec419d514eaa4215eaf14b612cff66398dd51129ac22680b20",
-                "sha256:7f627141a26b551bdebbc4855c1157feeef18241b4b8366ed22a5c7d672ef858",
-                "sha256:8169cf44dd8f9071b2b9248c35fc35e8677451c52f795daa2bb4643f32a540bc",
-                "sha256:aa00d66c0fab27373ae44ae26a66a9e43ff2a678bf63a9c7c1a9a4d61172827a",
-                "sha256:ccb032fda0873254380aa2bfad2582aedc2959186cce61e3a17abc1a55ff89c3",
-                "sha256:d754f39e0d1603b5b24a7f8484b22d2904fa551fe865fd0d4c3332f078d20d4e",
-                "sha256:d75c461e20e29afc0aee7172a0950157c704ff0dd51613506bd7d82b718e7410",
-                "sha256:dcd65317dd15bc0451f3e01c80da2216a31916bdcffd6221ca1202d96584aa25",
-                "sha256:e570d3ab32e2c2861c4ebe6ffcad6a8abf9347432a37608fe1fbd157b3f0036b",
-                "sha256:fd43a88e045cf992ed09fa724b5315b790525f2676883a6ea64e3263bae6549d"
-            ],
-            "version": "==1.13.2"
-        },
         "cfgv": {
             "hashes": [
-                "sha256:edb387943b665bf9c434f717bf630fa78aecd53d5900d2e05da6ad6048553144",
-                "sha256:fbd93c9ab0a523bf7daec408f3be2ed99a980e20b2d19b50fc184ca6b820d289"
+                "sha256:1ccf53320421aeeb915275a196e23b3b8ae87dea8ac6698b1638001d4a486d53",
+                "sha256:c8e8f552ffcc6194f4e18dd4f68d9aef0c0d58ae7e7be8c82bee3c5e9edfa513"
             ],
-            "version": "==2.0.1"
+            "version": "==3.1.0"
         },
         "chardet": {
             "hashes": [
@@ -372,40 +356,19 @@
             ],
             "version": "==5.0.3"
         },
-        "cryptography": {
+        "distlib": {
             "hashes": [
-                "sha256:02079a6addc7b5140ba0825f542c0869ff4df9a69c360e339ecead5baefa843c",
-                "sha256:1df22371fbf2004c6f64e927668734070a8953362cd8370ddd336774d6743595",
-                "sha256:369d2346db5934345787451504853ad9d342d7f721ae82d098083e1f49a582ad",
-                "sha256:3cda1f0ed8747339bbdf71b9f38ca74c7b592f24f65cdb3ab3765e4b02871651",
-                "sha256:44ff04138935882fef7c686878e1c8fd80a723161ad6a98da31e14b7553170c2",
-                "sha256:4b1030728872c59687badcca1e225a9103440e467c17d6d1730ab3d2d64bfeff",
-                "sha256:58363dbd966afb4f89b3b11dfb8ff200058fbc3b947507675c19ceb46104b48d",
-                "sha256:6ec280fb24d27e3d97aa731e16207d58bd8ae94ef6eab97249a2afe4ba643d42",
-                "sha256:7270a6c29199adc1297776937a05b59720e8a782531f1f122f2eb8467f9aab4d",
-                "sha256:73fd30c57fa2d0a1d7a49c561c40c2f79c7d6c374cc7750e9ac7c99176f6428e",
-                "sha256:7f09806ed4fbea8f51585231ba742b58cbcfbfe823ea197d8c89a5e433c7e912",
-                "sha256:90df0cc93e1f8d2fba8365fb59a858f51a11a394d64dbf3ef844f783844cc793",
-                "sha256:971221ed40f058f5662a604bd1ae6e4521d84e6cad0b7b170564cc34169c8f13",
-                "sha256:a518c153a2b5ed6b8cc03f7ae79d5ffad7315ad4569b2d5333a13c38d64bd8d7",
-                "sha256:b0de590a8b0979649ebeef8bb9f54394d3a41f66c5584fff4220901739b6b2f0",
-                "sha256:b43f53f29816ba1db8525f006fa6f49292e9b029554b3eb56a189a70f2a40879",
-                "sha256:d31402aad60ed889c7e57934a03477b572a03af7794fa8fb1780f21ea8f6551f",
-                "sha256:de96157ec73458a7f14e3d26f17f8128c959084931e8997b9e655a39c8fde9f9",
-                "sha256:df6b4dca2e11865e6cfbfb708e800efb18370f5a46fd601d3755bc7f85b3a8a2",
-                "sha256:ecadccc7ba52193963c0475ac9f6fa28ac01e01349a2ca48509667ef41ffd2cf",
-                "sha256:fb81c17e0ebe3358486cd8cc3ad78adbae58af12fc2bf2bc0bb84e8090fa5ce8"
+                "sha256:2e166e231a26b36d6dfe35a48c4464346620f8645ed0ace01ee31822b288de21"
             ],
-            "version": "==2.8"
+            "version": "==0.3.0"
         },
         "docutils": {
             "hashes": [
-                "sha256:6c4f696463b79f1fb8ba0c594b63840ebd41f059e92b31957c46b74a4599b6d0",
-                "sha256:9e4d7ecfc600058e07ba661411a2b7de2fd0fafa17d1a7f7361cd47b1175c827",
-                "sha256:a2aeea129088da402665e92e0b25b04b073c04b2dce4ab65caaa38b7ce2e1a99"
+                "sha256:0c5b78adfbf7762415433f5515cd5c9e762339e23369dbe8000d84a4bf4ab3af",
+                "sha256:c2de3a60e9e7d07be26b7f2b00ca0309c207e06c100f9cc2a94931fc75a478fc"
             ],
             "index": "pypi",
-            "version": "==0.15.2"
+            "version": "==0.16"
         },
         "entrypoints": {
             "hashes": [
@@ -413,6 +376,13 @@
                 "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"
             ],
             "version": "==0.3"
+        },
+        "filelock": {
+            "hashes": [
+                "sha256:18d82244ee114f543149c66a6e0c14e9c4f8a1044b5cdaadd0f82159d6a6ff59",
+                "sha256:929b7d63ec5b7d6b71b0fa5ac14e030b3f70b75747cef1b10da9b879fef15836"
+            ],
+            "version": "==3.0.12"
         },
         "flake8": {
             "hashes": [
@@ -439,11 +409,11 @@
         },
         "flake8-bugbear": {
             "hashes": [
-                "sha256:d8c466ea79d5020cb20bf9f11cf349026e09517a42264f313d3f6fddb83e0571",
-                "sha256:ded4d282778969b5ab5530ceba7aa1a9f1b86fa7618fc96a19a1d512331640f8"
+                "sha256:a3ddc03ec28ba2296fc6f89444d1c946a6b76460f859795b35b77d4920a51b63",
+                "sha256:bd02e4b009fb153fe6072c31c52aeab5b133d508095befb2ffcf3b41c4823162"
             ],
             "index": "pypi",
-            "version": "==19.8.0"
+            "version": "==20.1.4"
         },
         "flake8-builtins": {
             "hashes": [
@@ -455,11 +425,11 @@
         },
         "flake8-comprehensions": {
             "hashes": [
-                "sha256:6de428c3ac67d3614d527456469c8a3d6638960e9ad7e1222358526a2507400a",
-                "sha256:e3a8350a35d7bc71f8a1f64cf3c633a418a26b0edace2219d26ea4dd78ac21f3"
+                "sha256:d08323aa801aef33477cd33f2f5ce3acb1aafd26803ab0d171d85d514c1273a2",
+                "sha256:e7db586bb6eb95afdfd87ed244c90e57ae1352db8ef0ad3012fca0200421e5df"
             ],
             "index": "pypi",
-            "version": "==3.1.4"
+            "version": "==3.2.2"
         },
         "flake8-debugger": {
             "hashes": [
@@ -545,10 +515,18 @@
         },
         "idna": {
             "hashes": [
-                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
-                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+                "sha256:7588d1c14ae4c77d74036e8c22ff447b26d0fde8f007354fd48a7814db15b7cb",
+                "sha256:a068a21ceac8a4d63dbfd964670474107f541babbd2250d61922f029858365fa"
             ],
-            "version": "==2.8"
+            "version": "==2.9"
+        },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:06f5b3a99029c7134207dd882428a66992a9de2bef7c2b699b5641f9886c3302",
+                "sha256:b97607a1a18a5100839aec1dc26a1ea17ee0d93b20b0f008d80a5a050afb200b"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==1.5.0"
         },
         "isort": {
             "hashes": [
@@ -557,14 +535,6 @@
             ],
             "index": "pypi",
             "version": "==4.3.21"
-        },
-        "jeepney": {
-            "hashes": [
-                "sha256:0ba6d8c597e9bef1ebd18aaec595f942a264e25c1a48f164d46120eacaa2e9bb",
-                "sha256:6f45dce1125cf6c58a1c88123d3831f36a789f9204fbad3172eac15f8ccd08d0"
-            ],
-            "markers": "sys_platform == 'linux'",
-            "version": "==0.4.2"
         },
         "keyring": {
             "hashes": [
@@ -575,35 +545,36 @@
         },
         "lxml": {
             "hashes": [
-                "sha256:00ac0d64949fef6b3693813fe636a2d56d97a5a49b5bbb86e4cc4cc50ebc9ea2",
-                "sha256:0571e607558665ed42e450d7bf0e2941d542c18e117b1ebbf0ba72f287ad841c",
-                "sha256:0e3f04a7615fdac0be5e18b2406529521d6dbdb0167d2a690ee328bef7807487",
-                "sha256:13cf89be53348d1c17b453867da68704802966c433b2bb4fa1f970daadd2ef70",
-                "sha256:217262fcf6a4c2e1c7cb1efa08bd9ebc432502abc6c255c4abab611e8be0d14d",
-                "sha256:223e544828f1955daaf4cefbb4853bc416b2ec3fd56d4f4204a8b17007c21250",
-                "sha256:277cb61fede2f95b9c61912fefb3d43fbd5f18bf18a14fae4911b67984486f5d",
-                "sha256:3213f753e8ae86c396e0e066866e64c6b04618e85c723b32ecb0909885211f74",
-                "sha256:4690984a4dee1033da0af6df0b7a6bde83f74e1c0c870623797cec77964de34d",
-                "sha256:4fcc472ef87f45c429d3b923b925704aa581f875d65bac80f8ab0c3296a63f78",
-                "sha256:61409bd745a265a742f2693e4600e4dbd45cc1daebe1d5fad6fcb22912d44145",
-                "sha256:678f1963f755c5d9f5f6968dded7b245dd1ece8cf53c1aa9d80e6734a8c7f41d",
-                "sha256:6c6d03549d4e2734133badb9ab1c05d9f0ef4bcd31d83e5d2b4747c85cfa21da",
-                "sha256:6e74d5f4d6ecd6942375c52ffcd35f4318a61a02328f6f1bd79fcb4ffedf969e",
-                "sha256:7b4fc7b1ecc987ca7aaf3f4f0e71bbfbd81aaabf87002558f5bc95da3a865bcd",
-                "sha256:7ed386a40e172ddf44c061ad74881d8622f791d9af0b6f5be20023029129bc85",
-                "sha256:8f54f0924d12c47a382c600c880770b5ebfc96c9fd94cf6f6bdc21caf6163ea7",
-                "sha256:ad9b81351fdc236bda538efa6879315448411a81186c836d4b80d6ca8217cdb9",
-                "sha256:bbd00e21ea17f7bcc58dccd13869d68441b32899e89cf6cfa90d624a9198ce85",
-                "sha256:c3c289762cc09735e2a8f8a49571d0e8b4f57ea831ea11558247b5bdea0ac4db",
-                "sha256:cf4650942de5e5685ad308e22bcafbccfe37c54aa7c0e30cd620c2ee5c93d336",
-                "sha256:cfcbc33c9c59c93776aa41ab02e55c288a042211708b72fdb518221cc803abc8",
-                "sha256:e301055deadfedbd80cf94f2f65ff23126b232b0d1fea28f332ce58137bcdb18",
-                "sha256:ebbfe24df7f7b5c6c7620702496b6419f6a9aa2fd7f005eb731cc80d7b4692b9",
-                "sha256:eff69ddbf3ad86375c344339371168640951c302450c5d3e9936e98d6459db06",
-                "sha256:f6ed60a62c5f1c44e789d2cf14009423cb1646b44a43e40a9cf6a21f077678a1"
+                "sha256:06d4e0bbb1d62e38ae6118406d7cdb4693a3fa34ee3762238bcb96c9e36a93cd",
+                "sha256:0701f7965903a1c3f6f09328c1278ac0eee8f56f244e66af79cb224b7ef3801c",
+                "sha256:1f2c4ec372bf1c4a2c7e4bb20845e8bcf8050365189d86806bad1e3ae473d081",
+                "sha256:4235bc124fdcf611d02047d7034164897ade13046bda967768836629bc62784f",
+                "sha256:5828c7f3e615f3975d48f40d4fe66e8a7b25f16b5e5705ffe1d22e43fb1f6261",
+                "sha256:585c0869f75577ac7a8ff38d08f7aac9033da2c41c11352ebf86a04652758b7a",
+                "sha256:5d467ce9c5d35b3bcc7172c06320dddb275fea6ac2037f72f0a4d7472035cea9",
+                "sha256:63dbc21efd7e822c11d5ddbedbbb08cd11a41e0032e382a0fd59b0b08e405a3a",
+                "sha256:7bc1b221e7867f2e7ff1933165c0cec7153dce93d0cdba6554b42a8beb687bdb",
+                "sha256:8620ce80f50d023d414183bf90cc2576c2837b88e00bea3f33ad2630133bbb60",
+                "sha256:8a0ebda56ebca1a83eb2d1ac266649b80af8dd4b4a3502b2c1e09ac2f88fe128",
+                "sha256:90ed0e36455a81b25b7034038e40880189169c308a3df360861ad74da7b68c1a",
+                "sha256:95e67224815ef86924fbc2b71a9dbd1f7262384bca4bc4793645794ac4200717",
+                "sha256:afdb34b715daf814d1abea0317b6d672476b498472f1e5aacbadc34ebbc26e89",
+                "sha256:b4b2c63cc7963aedd08a5f5a454c9f67251b1ac9e22fd9d72836206c42dc2a72",
+                "sha256:d068f55bda3c2c3fcaec24bd083d9e2eede32c583faf084d6e4b9daaea77dde8",
+                "sha256:d5b3c4b7edd2e770375a01139be11307f04341ec709cf724e0f26ebb1eef12c3",
+                "sha256:deadf4df349d1dcd7b2853a2c8796593cc346600726eff680ed8ed11812382a7",
+                "sha256:df533af6f88080419c5a604d0d63b2c33b1c0c4409aba7d0cb6de305147ea8c8",
+                "sha256:e4aa948eb15018a657702fee0b9db47e908491c64d36b4a90f59a64741516e77",
+                "sha256:e5d842c73e4ef6ed8c1bd77806bf84a7cb535f9c0cf9b2c74d02ebda310070e1",
+                "sha256:ebec08091a22c2be870890913bdadd86fcd8e9f0f22bcb398abd3af914690c15",
+                "sha256:edc15fcfd77395e24543be48871c251f38132bb834d9fdfdad756adb6ea37679",
+                "sha256:f2b74784ed7e0bc2d02bd53e48ad6ba523c9b36c194260b7a5045071abbb1012",
+                "sha256:fa071559f14bd1e92077b1b5f6c22cf09756c6de7139370249eb372854ce51e6",
+                "sha256:fd52e796fee7171c4361d441796b64df1acfceb51f29e545e812f16d023c4bbc",
+                "sha256:fe976a0f1ef09b3638778024ab9fb8cde3118f203364212c198f71341c0715ca"
             ],
             "index": "pypi",
-            "version": "==4.4.2"
+            "version": "==4.5.0"
         },
         "mccabe": {
             "hashes": [
@@ -648,9 +619,9 @@
         },
         "nodeenv": {
             "hashes": [
-                "sha256:561057acd4ae3809e665a9aaaf214afff110bbb6a6d5c8a96121aea6878408b3"
+                "sha256:5b2438f2e42af54ca968dd1b374d14a1194848955187b0e5e4be1f73813a5212"
             ],
-            "version": "==1.3.4"
+            "version": "==1.3.5"
         },
         "packaging": {
             "hashes": [
@@ -675,19 +646,19 @@
         },
         "pre-commit": {
             "hashes": [
-                "sha256:9f152687127ec90642a2cc3e4d9e1e6240c4eb153615cb02aa1ad41d331cbb6e",
-                "sha256:c2e4810d2d3102d354947907514a78c5d30424d299dc0fe48f5aa049826e9b50"
+                "sha256:09ebe467f43ce24377f8c2f200fe3cd2570d328eb2ce0568c8e96ce19da45fa6",
+                "sha256:f8d555e31e2051892c7f7b3ad9f620bd2c09271d87e9eedb2ad831737d6211eb"
             ],
             "index": "pypi",
-            "version": "==1.20.0"
+            "version": "==2.1.1"
         },
         "pre-commit-hooks": {
             "hashes": [
-                "sha256:15bf8c088e406d987dec4c3bfbfb7d31d3bdbcb6ede71cf048cfc855f86afa77",
-                "sha256:94edbc072bf6c975961c99a32ab60e7a46be0b3c143f70208b2184694ffc590c"
+                "sha256:052adeef36b13c87f5c49922f15ca047993f09d4fe8fdfb091436f3e4a56892b",
+                "sha256:a03e2e78b7cdd07268935d83958dde66ad1e09eb23b8a3b115beb4f82fb541d6"
             ],
             "index": "pypi",
-            "version": "==2.4.0"
+            "version": "==2.5.0"
         },
         "py": {
             "hashes": [
@@ -703,19 +674,13 @@
             ],
             "version": "==2.5.0"
         },
-        "pycparser": {
-            "hashes": [
-                "sha256:a988718abfad80b6b157acce7bf130a30876d27603738ac39f140993246b25b3"
-            ],
-            "version": "==2.19"
-        },
         "pydocstyle": {
             "hashes": [
-                "sha256:4167fe954b8f27ebbbef2fbcf73c6e8ad1e7bb31488fce44a69fdfc4b0cd0fae",
-                "sha256:a0de36e549125d0a16a72a8c8c6c9ba267750656e72e466e994c222f1b6e92cb"
+                "sha256:da7831660b7355307b32778c4a0dbfb137d89254ef31a2b2978f50fc0b4d7586",
+                "sha256:f4f5d210610c2d153fae39093d44224c17429e2ad7da12a8b419aba5c2f614b5"
             ],
             "index": "pypi",
-            "version": "==5.0.1"
+            "version": "==5.0.2"
         },
         "pyflakes": {
             "hashes": [
@@ -740,11 +705,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:6b571215b5a790f9b41f19f3531c53a45cf6bb8ef2988bc1ff9afb38270b25fa",
-                "sha256:e41d489ff43948babd0fad7ad5e49b8735d5d55e26628a58673c39ff61d95de4"
+                "sha256:0d5fe9189a148acc3c3eb2ac8e1ac0742cb7618c084f3d228baaec0c254b318d",
+                "sha256:ff615c761e25eb25df19edddc0b970302d2a9091fbce0e7213298d85fb61fef6"
             ],
             "index": "pypi",
-            "version": "==5.3.2"
+            "version": "==5.3.5"
         },
         "pytest-cov": {
             "hashes": [
@@ -756,11 +721,11 @@
         },
         "pytest-randomly": {
             "hashes": [
-                "sha256:1ccaba7214858c681ff73da232f585a6fcccf0fe504e78ac38d077b3cba00b4e",
-                "sha256:2e89768ea851723b733cc57eb9e33b425490d1ebc858e7a122ade602d9cb58b6"
+                "sha256:8282a5a2066ed93d8d3eca6290538f34d09be05b7256ba94dba6fe3d2b1c514f",
+                "sha256:d9273db715bc7f8945cdb3efb994a9d15596a6087fb71a2e87030c5f2677317e"
             ],
             "index": "pypi",
-            "version": "==3.2.0"
+            "version": "==3.2.1"
         },
         "pyyaml": {
             "hashes": [
@@ -787,10 +752,10 @@
         },
         "requests": {
             "hashes": [
-                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
-                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+                "sha256:43999036bfa82904b6af1d99e4882b560e5e2c68e5c4b0aa03b655f3d7d73fee",
+                "sha256:b3f43d496c6daba4493e7c431722aeb7dbc6288f52a6e04e7b6023b0247817e6"
             ],
-            "version": "==2.22.0"
+            "version": "==2.23.0"
         },
         "requests-toolbelt": {
             "hashes": [
@@ -801,18 +766,35 @@
         },
         "ruamel.yaml": {
             "hashes": [
-                "sha256:9d59fa89985c55155d35c886663e357813404ae8f94638cb673135b8c8c1a7c7",
-                "sha256:dba517a7e330b6caf476b757022d21efa13c32694bfba1e057ce59a374f18f0a"
+                "sha256:0962fd7999e064c4865f96fb1e23079075f4a2a14849bcdc5cdba53a24f9759b",
+                "sha256:099c644a778bf72ffa00524f78dd0b6476bca94a1da344130f4bf3381ce5b954"
             ],
-            "version": "==0.16.7"
+            "version": "==0.16.10"
         },
-        "secretstorage": {
+        "ruamel.yaml.clib": {
             "hashes": [
-                "sha256:15da8a989b65498e29be338b3b279965f1b8f09b9668bd8010da183024c8bff6",
-                "sha256:b5ec909dde94d4ae2fa26af7c089036997030f0cf0a5cb372b4cccabd81c143b"
+                "sha256:1e77424825caba5553bbade750cec2277ef130647d685c2b38f68bc03453bac6",
+                "sha256:392b7c371312abf27fb549ec2d5e0092f7ef6e6c9f767bfb13e83cb903aca0fd",
+                "sha256:4d55386129291b96483edcb93b381470f7cd69f97585829b048a3d758d31210a",
+                "sha256:550168c02d8de52ee58c3d8a8193d5a8a9491a5e7b2462d27ac5bf63717574c9",
+                "sha256:57933a6986a3036257ad7bf283529e7c19c2810ff24c86f4a0cfeb49d2099919",
+                "sha256:615b0396a7fad02d1f9a0dcf9f01202bf9caefee6265198f252c865f4227fcc6",
+                "sha256:77556a7aa190be9a2bd83b7ee075d3df5f3c5016d395613671487e79b082d784",
+                "sha256:7aee724e1ff424757b5bd8f6c5bbdb033a570b2b4683b17ace4dbe61a99a657b",
+                "sha256:8073c8b92b06b572e4057b583c3d01674ceaf32167801fe545a087d7a1e8bf52",
+                "sha256:9c6d040d0396c28d3eaaa6cb20152cb3b2f15adf35a0304f4f40a3cf9f1d2448",
+                "sha256:a0ff786d2a7dbe55f9544b3f6ebbcc495d7e730df92a08434604f6f470b899c5",
+                "sha256:b1b7fcee6aedcdc7e62c3a73f238b3d080c7ba6650cd808bce8d7761ec484070",
+                "sha256:b66832ea8077d9b3f6e311c4a53d06273db5dc2db6e8a908550f3c14d67e718c",
+                "sha256:be018933c2f4ee7de55e7bd7d0d801b3dfb09d21dad0cce8a97995fd3e44be30",
+                "sha256:d0d3ac228c9bbab08134b4004d748cf9f8743504875b3603b3afbb97e3472947",
+                "sha256:d10e9dd744cf85c219bf747c75194b624cc7a94f0c80ead624b06bfa9f61d3bc",
+                "sha256:ea4362548ee0cbc266949d8a441238d9ad3600ca9910c3fe4e82ee3a50706973",
+                "sha256:ed5b3698a2bb241b7f5cbbe277eaa7fe48b07a58784fba4f75224fd066d253ad",
+                "sha256:f9dcc1ae73f36e8059589b601e8e4776b9976effd76c21ad6a855a74318efd6e"
             ],
-            "markers": "sys_platform == 'linux'",
-            "version": "==3.1.2"
+            "markers": "platform_python_implementation == 'CPython' and python_version < '3.9'",
+            "version": "==0.2.0"
         },
         "six": {
             "hashes": [
@@ -830,10 +812,10 @@
         },
         "soupsieve": {
             "hashes": [
-                "sha256:bdb0d917b03a1369ce964056fc195cfdff8819c40de04695a80bc813c3cfa1f5",
-                "sha256:e2c1c5dee4a1c36bcb790e0fabd5492d874b8ebd4617622c4f6a731701060dda"
+                "sha256:e914534802d7ffd233242b785229d5ba0766a7f487385e3f714446a07bf540ae",
+                "sha256:fcd71e08c0aee99aca1b73f45478549ee7e7fc006d51b37bec9e9def7dc22b69"
             ],
-            "version": "==1.9.5"
+            "version": "==2.0"
         },
         "toml": {
             "hashes": [
@@ -844,10 +826,10 @@
         },
         "tqdm": {
             "hashes": [
-                "sha256:251ee8440dbda126b8dfa8a7c028eb3f13704898caaef7caa699b35e119301e2",
-                "sha256:fe231261cfcbc6f4a99165455f8f6b9ef4e1032a6e29bccf168b4bf42012f09c"
+                "sha256:0d8b5afb66e23d80433102e9bd8b5c8b65d34c2a2255b2de58d97bd2ea8170fd",
+                "sha256:f35fb121bafa030bd94e74fcfd44f3c2830039a2ddef7fc87ef1c2d205237b24"
             ],
-            "version": "==4.42.1"
+            "version": "==4.43.0"
         },
         "twine": {
             "hashes": [
@@ -908,17 +890,16 @@
         },
         "virtualenv": {
             "hashes": [
-                "sha256:0d62c70883c0342d59c11d0ddac0d954d0431321a41ab20851facf2b222598f3",
-                "sha256:55059a7a676e4e19498f1aad09b8313a38fcc0cdbe4fdddc0e9b06946d21b4bb"
+                "sha256:30ea90b21dabd11da5f509710ad3be2ae47d40ccbc717dfdd2efe4367c10f598",
+                "sha256:4a36a96d785428278edd389d9c36d763c5755844beb7509279194647b1ef47f1"
             ],
-            "version": "==16.7.9"
+            "version": "==20.0.7"
         },
         "waitress": {
             "hashes": [
                 "sha256:045b3efc3d97c93362173ab1dfc159b52cfa22b46c3334ffc805dbdbf0e4309e",
                 "sha256:77ff3f3226931a1d7d8624c5371de07c8e90c7e5d80c5cc660d72659aaf23f38"
             ],
-            "index": "pypi",
             "version": "==1.4.3"
         },
         "wcwidth": {
@@ -944,11 +925,18 @@
         },
         "webtest": {
             "hashes": [
-                "sha256:41348efe4323a647a239c31cde84e5e440d726ca4f449859264e538d39037fd0",
-                "sha256:f3a603b8f1dd873b9710cd5a7dd0889cf758d7e1c133b1dae971c04f567e566e"
+                "sha256:71114cd778a7d7b237ec5c8a5c32084f447d869ae62e48bcd5b73af211133e74",
+                "sha256:da9cf14c103ff51a40dee4cac7657840d1317456eb8f0ca81289b5cbff175f4b"
             ],
             "index": "pypi",
-            "version": "==2.0.33"
+            "version": "==2.0.34"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:12248a63bbdf7548f89cb4c7cda4681e537031eda29c02ea29674bc6854460c2",
+                "sha256:7c0f8e91abc0dc07a5068f315c52cb30c66bfbc581e5b50704c8a2f6ebae794a"
+            ],
+            "version": "==3.0.0"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -64,7 +64,6 @@ The reason this package exists is to give you peace of mind when providing a RES
 config.include("pyramid_openapi3")
 config.pyramid_openapi3_spec('openapi.yaml', route='/api/v1/openapi.yaml')
 config.pyramid_openapi3_add_explorer(route='/api/v1/')
-config.pyramid_openapi3_JSONify_errors()
 ```
 
 3. Use the `openapi` [view predicate](https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/viewconfig.html#view-configuration-parameters) to enable request/response validation:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The reason this package exists is to give you peace of mind when providing a RES
 config.include("pyramid_openapi3")
 config.pyramid_openapi3_spec('openapi.yaml', route='/api/v1/openapi.yaml')
 config.pyramid_openapi3_add_explorer(route='/api/v1/')
+config.pyramid_openapi3_JSONify_errors()
 ```
 
 3. Use the `openapi` [view predicate](https://docs.pylonsproject.org/projects/pyramid/en/latest/narr/viewconfig.html#view-configuration-parameters) to enable request/response validation:
@@ -76,6 +77,7 @@ def myview(request):
 
 For requests, `request.openapi_validated` is available with two fields: `parameters` and `body`.
 For responses, if the payload does not match the API document, an exception is raised.
+
 
 ## Demo / Examples
 

--- a/examples/singlefile/app.py
+++ b/examples/singlefile/app.py
@@ -131,8 +131,4 @@ class FunctionalTests(unittest.TestCase):
         We don't have to write (and test!) any validation code in our view!
         """
         res = self.testapp.get("/hello?name=yo", status=400)
-        self.assertIn(
-            "Invalid parameter value for `name`: Value is shorter (2) "
-            "than the minimum length of 3",
-            res.text,
-        )
+        self.assertIn("'yo' is too short", res.text)

--- a/examples/todoapp/app.py
+++ b/examples/todoapp/app.py
@@ -57,7 +57,6 @@ def app():
             os.path.join(os.path.dirname(__file__), "openapi.yaml")
         )
         config.pyramid_openapi3_add_explorer()
-        config.pyramid_openapi3_JSONify_errors()
         config.add_route("todo", "/")
         config.scan(".")
 

--- a/examples/todoapp/openapi.yaml
+++ b/examples/todoapp/openapi.yaml
@@ -40,7 +40,9 @@ paths:
                 type: string
 
         '400':
-          $ref: '#/components/responses/BadRequest'
+          $ref: '#/components/responses/ValidationError'
+        '500':
+          $ref: '#/components/responses/ValidationError'
 
 
 components:
@@ -70,7 +72,7 @@ components:
 
   responses:
 
-    BadRequest:
+    ValidationError:
       description: OpenAPI request/response validation failed
       content:
         application/json:

--- a/examples/todoapp/tests.py
+++ b/examples/todoapp/tests.py
@@ -74,14 +74,18 @@ class TestBadResponses(TestHappyPath):
         """
         with mock.patch("app.ITEMS", ["foo", "bar"]):
             res = self.testapp.get("/", status=500)
-
         self.assertEqual(
             res.json,
             [
                 {
                     "exception": "ValidationError",
-                    "field": "items/type",
                     "message": "'foo' is not of type object",
-                }
+                    "field": "items/type",
+                },
+                {
+                    "exception": "ValidationError",
+                    "message": "'bar' is not of type object",
+                    "field": "items/type",
+                },
             ],
         )

--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -3,7 +3,7 @@
 from .exceptions import extract_error
 from .exceptions import RequestValidationError
 from .exceptions import ResponseValidationError
-from .wrappers import PyramidOpenAPIRequest
+from .wrappers import PyramidOpenAPIRequestFactory
 from openapi_core import create_spec
 from openapi_core.validation.request.validators import RequestValidator
 from openapi_core.validation.response.validators import ResponseValidator
@@ -68,7 +68,7 @@ def openapi_view(view: View, info: ViewDeriverInfo) -> t.Optional[View]:
             # Validate request and attach all findings for view to introspect
             request.environ["pyramid_openapi3.validate_response"] = True
             settings = request.registry.settings["pyramid_openapi3"]
-            openapi_request = PyramidOpenAPIRequest.create(request)
+            openapi_request = PyramidOpenAPIRequestFactory.create(request)
             request.openapi_validated = settings["request_validator"].validate(
                 openapi_request
             )

--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -1,6 +1,6 @@
 """Configure pyramid_openapi3 addon."""
 
-from .exceptions import extract_error
+from .exceptions import extract_errors
 from .exceptions import RequestValidationError
 from .exceptions import ResponseValidationError
 from .wrappers import PyramidOpenAPIRequestFactory
@@ -36,9 +36,9 @@ def includeme(config: Configurator) -> None:
     config.add_tween("pyramid_openapi3.tween.response_tween_factory", over=EXCVIEW)
 
     if not config.registry.settings.get(  # pragma: no branch
-        "pyramid_openapi3_extract_error"
+        "pyramid_openapi3_extract_errors"
     ):
-        config.registry.settings["pyramid_openapi3_extract_error"] = extract_error
+        config.registry.settings["pyramid_openapi3_extract_errors"] = extract_errors
 
     config.add_exception_view(
         view=openapi_validation_error, context=RequestValidationError, renderer="json"
@@ -178,8 +178,8 @@ def openapi_validation_error(
     if isinstance(context, ResponseValidationError):
         logger.warn(context)
 
-    extract_error = request.registry.settings["pyramid_openapi3_extract_error"]
-    errors = [extract_error(request, err) for err in context.errors]
+    extract_errors = request.registry.settings["pyramid_openapi3_extract_errors"]
+    errors = list(extract_errors(request, context.errors))
 
     # If validation failed for request, it is user's fault (-> 400), but if
     # validation failed for response, it is our fault (-> 500)

--- a/pyramid_openapi3/exceptions.py
+++ b/pyramid_openapi3/exceptions.py
@@ -94,6 +94,8 @@ def extract_error(err: OpenAPIError) -> t.Dict[str, str]:
         field = err.name
     elif getattr(err, "validator", None) is not None and err.validator == "required":
         field = "/".join(err.validator_value)
+    elif getattr(err, "validator", None) is not None and err.validator == "format":
+        field = None
     elif getattr(err, "path", None) and err.path[0]:
         field = "/".join(err.path)
     elif getattr(err, "relative_schema_path", None):

--- a/pyramid_openapi3/exceptions.py
+++ b/pyramid_openapi3/exceptions.py
@@ -1,4 +1,6 @@
 """Exceptions used in pyramid_openapi3."""
+
+from openapi_core.schema.exceptions import OpenAPIError
 from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.httpexceptions import HTTPInternalServerError
 
@@ -18,9 +20,6 @@ class RequestValidationError(HTTPBadRequest):
         """Return str(self.detail) or self.explanation."""
         return str(self.detail) if self.detail else self.explanation
 
-    def _json_formatter(self, status, body, title, environ) -> t.Dict:
-        return {"message": body, "code": status, "title": self.title}
-
 
 class ResponseValidationError(HTTPInternalServerError):
 
@@ -35,5 +34,72 @@ class ResponseValidationError(HTTPInternalServerError):
         """Return str(self.detail) or self.explanation."""
         return str(self.detail) if self.detail else self.explanation
 
-    def _json_formatter(self, status, body, title, environ) -> t.Dict:
-        return {"message": body, "code": status, "title": self.title}
+
+def extract_error(err: OpenAPIError) -> t.Dict[str, str]:
+    """Extract error's JSON response.
+
+    You can tell pyramid_openapi3 to use your own version of this
+    function by providing a dotted-name to your function in
+    `request.registry.settings["pyramid_openapi3_extract_error"]`.
+
+    This function expects the below definition in openapi.yaml
+    file. If your openapi.yaml is different, you have to
+    provide your own extract_error() function.
+
+    ```
+    components:
+
+      schemas:
+
+        Error:
+          type: object
+          required:
+            - exception
+            - message
+          properties:
+            field:
+              type: string
+            message:
+              type: string
+            exception:
+              type: string
+
+      responses:
+
+        ValidationError:
+          description: OpenAPI request/response validation failed
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Error"
+    ```
+    """
+    if getattr(err, "schema_errors", None) is not None:
+        for schema_error in err.schema_errors:  # pragma: no branch
+            return extract_error(schema_error)
+
+    output = {"exception": err.__class__.__name__}
+
+    if getattr(err, "message", None) is not None:
+        message = err.message
+    else:
+        message = str(err)
+
+    output.update({"message": message})
+
+    field = None
+    if getattr(err, "name", None) is not None:
+        field = err.name
+    elif getattr(err, "validator", None) is not None and err.validator == "required":
+        field = "/".join(err.validator_value)
+    elif getattr(err, "path", None) and err.path[0]:
+        field = "/".join(err.path)
+    elif getattr(err, "relative_schema_path", None):
+        field = "/".join(err.relative_schema_path)
+
+    if field:
+        output.update({"field": field})
+
+    return output

--- a/pyramid_openapi3/exceptions.py
+++ b/pyramid_openapi3/exceptions.py
@@ -96,7 +96,9 @@ def extract_error(request: Request, err: OpenAPIError) -> t.Dict[str, str]:
     elif getattr(err, "validator", None) is not None and err.validator == "required":
         field = "/".join(err.validator_value)
     elif getattr(err, "validator", None) is not None and err.validator == "format":
-        field = None
+        field = None  # TODO: figure out how to get field name here
+    elif getattr(err, "validator", None) is not None and err.validator == "pattern":
+        field = None  # TODO: figure out how to get field name here
     elif getattr(err, "path", None) and err.path[0]:
         field = "/".join(err.path)
     elif getattr(err, "relative_schema_path", None):

--- a/pyramid_openapi3/exceptions.py
+++ b/pyramid_openapi3/exceptions.py
@@ -3,6 +3,7 @@
 from openapi_core.schema.exceptions import OpenAPIError
 from pyramid.httpexceptions import HTTPBadRequest
 from pyramid.httpexceptions import HTTPInternalServerError
+from pyramid.request import Request
 
 import typing as t
 
@@ -35,7 +36,7 @@ class ResponseValidationError(HTTPInternalServerError):
         return str(self.detail) if self.detail else self.explanation
 
 
-def extract_error(err: OpenAPIError) -> t.Dict[str, str]:
+def extract_error(request: Request, err: OpenAPIError) -> t.Dict[str, str]:
     """Extract error's JSON response.
 
     You can tell pyramid_openapi3 to use your own version of this
@@ -78,7 +79,7 @@ def extract_error(err: OpenAPIError) -> t.Dict[str, str]:
     """
     if getattr(err, "schema_errors", None) is not None:
         for schema_error in err.schema_errors:  # pragma: no branch
-            return extract_error(schema_error)
+            return extract_error(request, schema_error)
 
     output = {"exception": err.__class__.__name__}
 

--- a/pyramid_openapi3/tests/test_extract_error.py
+++ b/pyramid_openapi3/tests/test_extract_error.py
@@ -1,0 +1,281 @@
+"""Test rendering errors as JSON responses."""
+
+from pyramid.config import Configurator
+from pyramid.httpexceptions import exception_response
+from pyramid.router import Router
+from webtest.app import TestApp
+
+import tempfile
+import typing as t
+import unittest
+
+
+def app(spec: str, view: t.Callable) -> Router:
+    """Prepare a Pyramid app."""
+    with Configurator() as config:
+        config.include("pyramid_openapi3")
+        config.pyramid_openapi3_spec(spec)
+        config.pyramid_openapi3_JSONify_errors()
+        config.add_route("foo", "/foo")
+        config.add_view(openapi=True, renderer="json", view=view, route_name="foo")
+        return config.make_wsgi_app()
+
+
+class BadRequestsTests(unittest.TestCase):
+    """A suite of tests that make sure bad requests are handled."""
+
+    def foo(*args) -> None:  # noqa: D102
+        return None  # pragma: no cover
+
+    OPENAPI_YAML = """
+        openapi: "3.0.0"
+        info:
+          version: "1.0.0"
+          title: Foo
+        paths:
+          /foo:
+            post:
+              {parameters}
+              responses:
+                200:
+                  description: Say hello
+                400:
+                  description: Bad Request
+    """
+
+    def _testapp(self, view: t.Callable, parameters: str) -> TestApp:
+        """Start up the app so that tests can send requests to it."""
+        from webtest import TestApp
+
+        with tempfile.NamedTemporaryFile() as document:
+            document.write(self.OPENAPI_YAML.format(parameters=parameters).encode())
+            document.seek(0)
+
+            return TestApp(app(document.name, view))
+
+    def test_missing_path_parameter(self) -> None:
+        """Render nice ValidationError if path parameter is missing."""
+
+        parameters = """
+              parameters:
+                - name: bar
+                  in: query
+                  required: true
+                  schema:
+                    type: integer
+        """
+
+        res = self._testapp(view=self.foo, parameters=parameters).post(
+            "/foo", status=400
+        )
+        assert res.json == [
+            {
+                "exception": "MissingRequiredParameter",
+                "message": "Missing required parameter: bar",
+                "field": "bar",
+            }
+        ]
+
+    def test_missing_header_parameter(self) -> None:
+        """Render nice ValidationError if header parameter is missing."""
+
+        parameters = """
+              parameters:
+                - name: bar
+                  in: header
+                  required: true
+                  schema:
+                    type: integer
+        """
+
+        res = self._testapp(view=self.foo, parameters=parameters).post(
+            "/foo", status=400
+        )
+        assert res.json == [
+            {
+                "exception": "MissingRequiredParameter",
+                "message": "Missing required parameter: bar",
+                "field": "bar",
+            }
+        ]
+
+    def test_missing_cookie_parameter(self) -> None:
+        """Render nice ValidationError if cookie parameter is missing."""
+
+        parameters = """
+              parameters:
+                - name: bar
+                  in: cookie
+                  required: true
+                  schema:
+                    type: integer
+        """
+
+        res = self._testapp(view=self.foo, parameters=parameters).post(
+            "/foo", status=400
+        )
+        assert res.json == [
+            {
+                "exception": "MissingRequiredParameter",
+                "message": "Missing required parameter: bar",
+                "field": "bar",
+            }
+        ]
+
+    def test_missing_POST_parameter(self) -> None:
+        """Render nice ValidationError if POST parameter is missing."""
+
+        parameters = """
+              requestBody:
+                required: true
+                description: Data for saying foo
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      required:
+                        - foo
+                      properties:
+                        foo:
+                          type: string
+        """
+
+        res = self._testapp(view=self.foo, parameters=parameters).post_json(
+            "/foo", {}, status=400
+        )
+        assert res.json == [
+            {
+                "exception": "ValidationError",
+                "message": "'foo' is a required property",
+                "field": "foo",
+            }
+        ]
+
+    def test_missing_type_POST_parameter(self) -> None:
+        """Render nice ValidationError if POST parameter is of invalid type."""
+
+        parameters = """
+              requestBody:
+                required: true
+                description: Data for saying foo
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      required:
+                        - foo
+                      properties:
+                        foo:
+                          type: string
+        """
+
+        res = self._testapp(view=self.foo, parameters=parameters).post_json(
+            "/foo", {"foo": 1}, status=400
+        )
+        assert res.json == [
+            {
+                "exception": "ValidationError",
+                "message": "1 is not of type string",
+                "field": "foo",
+            }
+        ]
+
+    def test_invalid_length_POST_parameter(self) -> None:
+        """Render nice ValidationError if POST parameter is of invalid length."""
+        parameters = """
+              requestBody:
+                required: true
+                description: Data for saying foo
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        foo:
+                          type: string
+                          minLength: 3
+        """
+
+        res = self._testapp(view=self.foo, parameters=parameters).post_json(
+            "/foo", {"foo": "12"}, status=400
+        )
+        assert res.json == [
+            {
+                "exception": "ValidationError",
+                "message": "'12' is too short",
+                "field": "foo",
+            }
+        ]
+
+
+class BadResponsesTests(unittest.TestCase):
+    """A suite of tests that make sure bad responses are prevented."""
+
+    OPENAPI_YAML = b"""
+        openapi: "3.0.0"
+        info:
+          version: "1.0.0"
+          title: Foo
+        paths:
+          /foo:
+            get:
+              responses:
+                200:
+                  description: Say foo
+                400:
+                  description: Bad Request
+                  content:
+                    application/json:
+                      schema:
+                        type: string
+    """
+
+    def _testapp(self, view: t.Callable) -> TestApp:
+        """Start up the app so that tests can send requests to it."""
+        from webtest import TestApp
+
+        with tempfile.NamedTemporaryFile() as document:
+            document.write(self.OPENAPI_YAML)
+            document.seek(0)
+
+            return TestApp(app(document.name, view))
+
+    def test_foo(self) -> None:
+        """Say foo."""
+
+        def foo(*args):
+            """Say foobar."""
+            return {"foo": "bar"}
+
+        res = self._testapp(view=foo).get("/foo", status=200)
+        self.assertIn('{"foo": "bar"}', res.text)
+
+    def test_invalid_response_code(self) -> None:
+        """Prevent responding with undefined response code."""
+
+        def foo(*args):
+            raise exception_response(409, json_body={})
+
+        res = self._testapp(view=foo).get("/foo", status=500)
+        assert res.json == [
+            {
+                "exception": "InvalidResponse",
+                "message": "Unknown response http status: 409",
+            }
+        ]
+
+    def test_invalid_response_schema(self) -> None:
+        """Prevent responding with unmatching response schema."""
+        from pyramid.httpexceptions import exception_response
+
+        def foo(*args):
+            raise exception_response(400, json_body={"foo": "bar"})
+
+        res = self._testapp(view=foo).get("/foo", status=500)
+        assert res.json == [
+            {
+                "exception": "ValidationError",
+                "message": "{'foo': 'bar'} is not of type string",
+                "field": "type",
+            }
+        ]

--- a/pyramid_openapi3/tests/test_extract_error.py
+++ b/pyramid_openapi3/tests/test_extract_error.py
@@ -15,7 +15,6 @@ def app(spec: str, view: t.Callable, route: str) -> Router:
     with Configurator() as config:
         config.include("pyramid_openapi3")
         config.pyramid_openapi3_spec(spec)
-        config.pyramid_openapi3_JSONify_errors()
         config.add_route("foo", route)
         config.add_view(openapi=True, renderer="json", view=view, route_name="foo")
         return config.make_wsgi_app()

--- a/pyramid_openapi3/tests/test_extract_error.py
+++ b/pyramid_openapi3/tests/test_extract_error.py
@@ -127,6 +127,37 @@ class BadRequestsTests(unittest.TestCase):
             }
         ]
 
+    def test_invalid_path_parameter_regex(self) -> None:
+        """Render nice ValidationError if path parameter does not match regex."""
+        endpoints = """
+          "/foo/{bar}":
+            post:
+              parameters:
+                - name: bar
+                  in: path
+                  required: true
+                  schema:
+                    type: string
+                    pattern: '^[0-9]{2}-[A-F]{4}$'
+              responses:
+                200:
+                  description: Say hello
+                400:
+                  description: Bad Request
+        """
+
+        res = self._testapp(
+            view=self.foo, endpoints=endpoints, route="/foo/{bar}"
+        ).post("/foo/not-a-valid-uuid", status=400)
+        assert res.json == [
+            {
+                "exception": "ValidationError",
+                "message": "'not-a-valid-uuid' does not match '^[0-9]{2}-[A-F]{4}$'",
+                # TODO: ideally, this response would include "field"
+                # but I don't know how I can achieve this ATM ¯\_(ツ)_/¯
+            }
+        ]
+
     def test_invalid_path_parameter_uuid(self) -> None:
         """Render nice ValidationError if path parameter is not UUID."""
         endpoints = """

--- a/pyramid_openapi3/tests/test_validation.py
+++ b/pyramid_openapi3/tests/test_validation.py
@@ -1,4 +1,5 @@
-"""Test validaion exceptions."""
+"""Test validation exceptions."""
+
 from dataclasses import dataclass
 from pyramid.interfaces import IRouteRequest
 from pyramid.interfaces import IView
@@ -9,10 +10,12 @@ from pyramid.router import Router
 from pyramid.testing import DummyRequest
 from pyramid.testing import setUp
 from pyramid.testing import tearDown
+from pyramid_openapi3.exceptions import ResponseValidationError
 from unittest import TestCase
 from zope.interface import Interface
 
 import json
+import pytest
 import tempfile
 import typing as t
 
@@ -90,16 +93,6 @@ class TestRequestValidation(TestCase):
             openapi=openapi, renderer="json", view=view_func, route_name="foo"
         )
 
-    def _add_default_exception_view(self) -> None:
-        """Install Pyramid default_exception_response_view."""
-        # setup default exception response view
-        from pyramid.httpexceptions import default_exceptionresponse_view
-        from pyramid.interfaces import IExceptionResponse
-
-        self.config.add_view(
-            view=default_exceptionresponse_view, context=IExceptionResponse
-        )
-
     def _get_view(self) -> View:
         """Return wrapped view method registered in _add_view."""
         request_interface = self.config.registry.queryUtility(IRouteRequest, name="foo")
@@ -113,28 +106,11 @@ class TestRequestValidation(TestCase):
 
         :param params: Query parameter dictionary
         """
-        request = DummyRequest(config=self.config, params=params)
+        request = DummyRequest(
+            config=self.config, params=params, content_type="text/html"
+        )
         request.matched_route = DummyRoute(name="foo", pattern="/foo")
         return request
-
-    def test_request_validation_error(self) -> None:
-        """Test View raises RequestValidationError.
-
-        Request parameters don't match schema.
-        """
-        self._add_view()
-        view = self._get_view()
-        request = self._get_request()
-        from pyramid_openapi3 import RequestValidationError
-
-        with self.assertRaises(RequestValidationError) as cm:
-            view(None, request)
-        response = cm.exception
-        self.assertEqual(str(cm.exception), "Missing required parameter: bar")
-        # not enough of pyramid has been set up so we need to render the
-        # exception response ourselves.
-        response.prepare({"HTTP_ACCEPT": "application/json"})
-        self.assertIn("Missing required parameter: bar", response.json["message"])
 
     def test_view_raises_valid_http_exception(self) -> None:
         """Test View raises HTTPException.
@@ -157,13 +133,10 @@ class TestRequestValidation(TestCase):
         response.prepare({"HTTP_ACCEPT": "application/json"})
         self.assertIn("bad foo request", response.json["message"])
 
-    def test_default_exception_view(self) -> None:
-        """Test Pyramid default exception response view.
-
-        Pyramid default exception response view renders a RequestValidationError.
-        """
+    def test_request_validation_error(self) -> None:
+        """Request validation errors are rendered as 400 JSON responses."""
         self._add_view()
-        self._add_default_exception_view()
+        self.config.pyramid_openapi3_JSONify_errors()
         # run request through router
         router = Router(self.config.registry)
         environ = {
@@ -177,8 +150,15 @@ class TestRequestValidation(TestCase):
         start_response = DummyStartResponse()
         response = router(environ, start_response)
         self.assertEqual(start_response.status, "400 Bad Request")
-        self.assertIn(
-            "Missing required parameter: bar", json.loads(b"".join(response))["message"]
+        self.assertEqual(
+            json.loads(response[0]),
+            [
+                {
+                    "exception": "MissingRequiredParameter",
+                    "message": "Missing required parameter: bar",
+                    "field": "bar",
+                }
+            ],
         )
 
     def test_response_validation_error(self) -> None:
@@ -190,8 +170,8 @@ class TestRequestValidation(TestCase):
         """
         from pyramid.httpexceptions import HTTPPreconditionFailed
 
-        self._add_view(lambda *arg: (_ for _ in ()).throw(HTTPPreconditionFailed()))
-        self._add_default_exception_view()
+        self._add_view(lambda *arg: HTTPPreconditionFailed())
+
         # run request through router
         router = Router(self.config.registry)
         environ = {
@@ -204,11 +184,23 @@ class TestRequestValidation(TestCase):
             "QUERY_STRING": "bar=1",
         }
         start_response = DummyStartResponse()
+        with pytest.raises(
+            ResponseValidationError, match="Unknown response http status: 412"
+        ):
+            response = router(environ, start_response)
+
+        self.config.pyramid_openapi3_JSONify_errors()
+        start_response = DummyStartResponse()
         response = router(environ, start_response)
         self.assertEqual(start_response.status, "500 Internal Server Error")
-        self.assertIn(
-            "Unknown response http status: 412",
-            json.loads(b"".join(response))["message"],
+        self.assertEqual(
+            json.loads(response[0]),
+            [
+                {
+                    "exception": "InvalidResponse",
+                    "message": "Unknown response http status: 412",
+                }
+            ],
         )
 
     def test_nonapi_view(self) -> None:
@@ -227,56 +219,3 @@ class TestRequestValidation(TestCase):
         response = router(environ, start_response)
         self.assertEqual(start_response.status, "200 OK")
         self.assertIn(b"foo", b"".join(response))
-
-    def test_nonapi_view_exception(self) -> None:
-        """Test View without openapi validation raises HTTPException.
-
-        Example view raises a defined response code.
-        """
-        from pyramid.httpexceptions import HTTPBadRequest
-
-        def view_func(*args):
-            raise HTTPBadRequest("bad foo request")
-
-        self._add_view(view_func, openapi=False)
-        self._add_default_exception_view()
-        # run request through router
-        router = Router(self.config.registry)
-        environ = {
-            "wsgi.url_scheme": "http",
-            "SERVER_NAME": "localhost",
-            "SERVER_PORT": "8080",
-            "REQUEST_METHOD": "GET",
-            "PATH_INFO": "/foo",
-        }
-        start_response = DummyStartResponse()
-        response = router(environ, start_response)
-        self.assertEqual(start_response.status, "400 Bad Request")
-        self.assertIn(b"foo", b"".join(response))
-
-    def test_no_default_exception_view(self) -> None:
-        """Test Response Validation Error without default exception view.
-
-        This causes the ResponseValidationError to bubble up to the top, because
-        there is no view to render the HTTPException into a response.
-        """
-        from pyramid.httpexceptions import HTTPPreconditionFailed
-        from pyramid_openapi3.exceptions import ResponseValidationError
-
-        # return the exception, so that response validation can kick in
-        self._add_view(lambda *arg: HTTPPreconditionFailed())
-        # run request through router
-        router = Router(self.config.registry)
-        environ = {
-            "wsgi.url_scheme": "http",
-            "SERVER_NAME": "localhost",
-            "SERVER_PORT": "8080",
-            "REQUEST_METHOD": "GET",
-            "PATH_INFO": "/foo",
-            "QUERY_STRING": "bar=1",
-        }
-        start_response = DummyStartResponse()
-        with self.assertRaises(ResponseValidationError) as cm:
-            router(environ, start_response)
-        self.assertEqual(cm.exception.status_code, 500)
-        self.assertEqual("Unknown response http status: 412", str(cm.exception))

--- a/pyramid_openapi3/tests/test_views.py
+++ b/pyramid_openapi3/tests/test_views.py
@@ -4,8 +4,6 @@ from dataclasses import dataclass
 from openapi_core.shortcuts import RequestValidator
 from openapi_core.shortcuts import ResponseValidator
 from pyramid.exceptions import ConfigurationError
-from pyramid.httpexceptions import exception_response
-from pyramid.httpexceptions import HTTPForbidden
 from pyramid.interfaces import IRouteRequest
 from pyramid.interfaces import IRoutesMapper
 from pyramid.interfaces import IView
@@ -104,13 +102,11 @@ def test_explorer_view_missing_spec() -> None:
         view = config.registry.adapters.registered(
             (IViewClassifier, request, Interface), IView, name=""
         )
-        with pytest.raises(ConfigurationError) as exc:
+        with pytest.raises(
+            ConfigurationError,
+            match="You need to call config.pyramid_openapi3_spec for explorer to work.",
+        ):
             view(request=DummyRequest(config=config), context=None)
-
-        assert (
-            str(exc.value)
-            == "You need to call config.pyramid_openapi3_spec for explorer to work."
-        )
 
 
 @dataclass
@@ -140,48 +136,12 @@ def test_openapi_view() -> None:
         view = config.registry.adapters.registered(
             (IViewClassifier, request_interface, Interface), IView, name=""
         )
-        request = DummyRequest(config=config)
+        request = DummyRequest(config=config, content_type="text/html")
         request.matched_route = DummyRoute(name="foo", pattern="/foo")
         context = None
         response = view(context, request)
 
         assert response.json == "bar"
-
-
-def test_openapi_view_validate_HTTPExceptions() -> None:
-    """Test that raised HTTPExceptions are validated against the spec.
-
-    I.e. create a dummy view that raises 403 Forbidden. The openapi integration
-    should re-raise it as InvalidResponse because 403 is not on the list of
-    responses in MINIMAL_DOCUMENT.
-    """
-    with testConfig() as config:
-        config.include("pyramid_openapi3")
-
-        with tempfile.NamedTemporaryFile() as document:
-            document.write(MINIMAL_DOCUMENT)
-            document.seek(0)
-
-            config.pyramid_openapi3_spec(
-                document.name, route="/foo.yaml", route_name="foo_api_spec"
-            )
-
-        config.add_route("foo", "/foo")
-        view_func = lambda *arg: (_ for _ in ()).throw(  # noqa: E731
-            exception_response(403, json_body="Forbidden")
-        )
-        config.add_view(openapi=True, renderer="json", view=view_func, route_name="foo")
-
-        request_interface = config.registry.queryUtility(IRouteRequest, name="foo")
-        view = config.registry.adapters.registered(
-            (IViewClassifier, request_interface, Interface), IView, name=""
-        )
-        request = DummyRequest(config=config)
-        request.matched_route = DummyRoute(name="foo", pattern="/foo")
-        context = None
-
-        with pytest.raises(HTTPForbidden):
-            view(context, request)
 
 
 def test_path_parameters() -> None:
@@ -222,16 +182,18 @@ def test_path_parameters() -> None:
             (IViewClassifier, request_interface, Interface), IView, name=""
         )
         # Test validation fails
-        request = DummyRequest(config=config)
+        request = DummyRequest(config=config, content_type="application/json")
         request.matched_route = DummyRoute(name="foo", pattern="/foo")
         context = None
-        with pytest.raises(RequestValidationError) as exc:
+        with pytest.raises(
+            RequestValidationError, match="Missing required parameter: foo"
+        ):
             response = view(context, request)
 
-        assert str(exc.value) == "Missing required parameter: foo"
-
         # Test validation succeeds
-        request = DummyRequest(config=config, params={"foo": "1"})
+        request = DummyRequest(
+            config=config, params={"foo": "1"}, content_type="application/json"
+        )
         request.matched_route = DummyRoute(name="foo", pattern="/foo")
         context = None
         response = view(context, request)
@@ -277,17 +239,19 @@ def test_header_parameters() -> None:
             (IViewClassifier, request_interface, Interface), IView, name=""
         )
         # Test validation fails
-        request = DummyRequest(config=config)
+        request = DummyRequest(config=config, content_type="text/html")
         request.matched_route = DummyRoute(name="foo", pattern="/foo")
         context = None
 
-        with pytest.raises(RequestValidationError) as exc:
+        with pytest.raises(
+            RequestValidationError, match="Missing required parameter: foo"
+        ):
             response = view(context, request)
 
-        assert str(exc.value) == "Missing required parameter: foo"
-
         # Test validation succeeds
-        request = DummyRequest(config=config, headers={"foo": "1"})
+        request = DummyRequest(
+            config=config, headers={"foo": "1"}, content_type="text/html"
+        )
         request.matched_route = DummyRoute(name="foo", pattern="/foo")
         context = None
         response = view(context, request)
@@ -333,16 +297,18 @@ def test_cookie_parameters() -> None:
             (IViewClassifier, request_interface, Interface), IView, name=""
         )
         # Test validation fails
-        request = DummyRequest(config=config)
+        request = DummyRequest(config=config, content_type="text/html")
         request.matched_route = DummyRoute(name="foo", pattern="/foo")
         context = None
-        with pytest.raises(RequestValidationError) as exc:
+        with pytest.raises(
+            RequestValidationError, match="Missing required parameter: foo"
+        ):
             response = view(context, request)
 
-        assert str(exc.value) == "Missing required parameter: foo"
-
         # Test validation succeeds
-        request = DummyRequest(config=config, cookies={"foo": "1"})
+        request = DummyRequest(
+            config=config, cookies={"foo": "1"}, content_type="text/html"
+        )
         request.matched_route = DummyRoute(name="foo", pattern="/foo")
         context = None
         response = view(context, request)

--- a/pyramid_openapi3/tests/test_wrappers.py
+++ b/pyramid_openapi3/tests/test_wrappers.py
@@ -3,8 +3,8 @@
 from dataclasses import dataclass
 from openapi_core.validation.request.datatypes import RequestParameters
 from pyramid.testing import DummyRequest
-from pyramid_openapi3.wrappers import PyramidOpenAPIRequest
-from pyramid_openapi3.wrappers import PyramidOpenAPIResponse
+from pyramid_openapi3.wrappers import PyramidOpenAPIRequestFactory
+from pyramid_openapi3.wrappers import PyramidOpenAPIResponseFactory
 
 
 @dataclass
@@ -27,7 +27,7 @@ def test_mapped_values_request() -> None:
     assert pyramid_request.path == "/foo"
     assert pyramid_request.method == "GET"
 
-    openapi_request = PyramidOpenAPIRequest.create(pyramid_request)
+    openapi_request = PyramidOpenAPIRequestFactory.create(pyramid_request)
 
     assert openapi_request.full_url_pattern == "http://example.com/foo"
     assert openapi_request.method == "get"
@@ -47,7 +47,7 @@ def test_no_matched_route() -> None:
     pyramid_request.matched_route = None
     pyramid_request.content_type = "text/html"
 
-    openapi_request = PyramidOpenAPIRequest.create(pyramid_request)
+    openapi_request = PyramidOpenAPIRequestFactory.create(pyramid_request)
     assert openapi_request.full_url_pattern == "http://example.com/foo"
 
 
@@ -59,7 +59,7 @@ def test_mapped_values_response() -> None:
     assert pyramid_request.response.status_code == 200
     assert pyramid_request.response.content_type == "text/html"
 
-    openapi_response = PyramidOpenAPIResponse.create(pyramid_request.response)
+    openapi_response = PyramidOpenAPIResponseFactory.create(pyramid_request.response)
 
     assert openapi_response.data == b""
     assert openapi_response.status_code == 200

--- a/pyramid_openapi3/tests/test_wrappers.py
+++ b/pyramid_openapi3/tests/test_wrappers.py
@@ -1,6 +1,7 @@
 """Tests for the wrappers.py module."""
 
 from dataclasses import dataclass
+from openapi_core.validation.request.datatypes import RequestParameters
 from pyramid.testing import DummyRequest
 from pyramid_openapi3.wrappers import PyramidOpenAPIRequest
 from pyramid_openapi3.wrappers import PyramidOpenAPIResponse
@@ -26,30 +27,28 @@ def test_mapped_values_request() -> None:
     assert pyramid_request.path == "/foo"
     assert pyramid_request.method == "GET"
 
-    openapi_request = PyramidOpenAPIRequest(pyramid_request)
+    openapi_request = PyramidOpenAPIRequest.create(pyramid_request)
 
-    assert openapi_request.request == pyramid_request
-    assert openapi_request.host_url == "http://example.com"
-    assert openapi_request.path == "/foo"
+    assert openapi_request.full_url_pattern == "http://example.com/foo"
     assert openapi_request.method == "get"
-    assert openapi_request.path_pattern == "/foo"
     assert openapi_request.body == ""
     assert openapi_request.mimetype == "text/html"
-    assert openapi_request.parameters == {
-        "cookie": {"tasty-foo": "tasty-bar"},
-        "header": {"X-Foo": "Bar"},
-        "path": {"foo": "bar"},
-        "query": {},
-    }
+    assert openapi_request.parameters == RequestParameters(
+        path={"foo": "bar"},
+        query={},
+        header={"X-Foo": "Bar"},
+        cookie={"tasty-foo": "tasty-bar"},
+    )
 
 
 def test_no_matched_route() -> None:
     """Test path_pattern when no route is matched."""
     pyramid_request = DummyRequest(path="/foo")
     pyramid_request.matched_route = None
+    pyramid_request.content_type = "text/html"
 
-    openapi_request = PyramidOpenAPIRequest(pyramid_request)
-    assert openapi_request.path_pattern == "/foo"
+    openapi_request = PyramidOpenAPIRequest.create(pyramid_request)
+    assert openapi_request.full_url_pattern == "http://example.com/foo"
 
 
 def test_mapped_values_response() -> None:
@@ -60,9 +59,8 @@ def test_mapped_values_response() -> None:
     assert pyramid_request.response.status_code == 200
     assert pyramid_request.response.content_type == "text/html"
 
-    openapi_response = PyramidOpenAPIResponse(pyramid_request.response)
+    openapi_response = PyramidOpenAPIResponse.create(pyramid_request.response)
 
-    assert openapi_response.response == pyramid_request.response
     assert openapi_response.data == b""
     assert openapi_response.status_code == 200
     assert openapi_response.mimetype == "text/html"

--- a/pyramid_openapi3/tween.py
+++ b/pyramid_openapi3/tween.py
@@ -1,8 +1,8 @@
 """A tween to validate openapi responses."""
 
 from .exceptions import ResponseValidationError
-from .wrappers import PyramidOpenAPIRequest
-from .wrappers import PyramidOpenAPIResponse
+from .wrappers import PyramidOpenAPIRequestFactory
+from .wrappers import PyramidOpenAPIResponseFactory
 from pyramid.request import Request
 from pyramid.response import Response
 
@@ -29,8 +29,8 @@ def response_tween_factory(handler, registry) -> t.Callable[[Request], Response]
                 # not an openapi view or response validation not requested
                 return response
             # validate response
-            openapi_request = PyramidOpenAPIRequest.create(request)
-            openapi_response = PyramidOpenAPIResponse.create(response)
+            openapi_request = PyramidOpenAPIRequestFactory.create(request)
+            openapi_response = PyramidOpenAPIResponseFactory.create(response)
             settings = request.registry.settings["pyramid_openapi3"]
             result = settings["response_validator"].validate(
                 request=openapi_request, response=openapi_response

--- a/pyramid_openapi3/tween.py
+++ b/pyramid_openapi3/tween.py
@@ -3,12 +3,9 @@
 from .exceptions import ResponseValidationError
 from .wrappers import PyramidOpenAPIRequest
 from .wrappers import PyramidOpenAPIResponse
-from pyramid.httpexceptions import HTTPNotFound
 from pyramid.request import Request
 from pyramid.response import Response
-from pyramid.tweens import reraise
 
-import sys
 import typing as t
 
 
@@ -42,14 +39,7 @@ def response_tween_factory(handler, registry) -> t.Callable[[Request], Response]
                 raise ResponseValidationError(errors=result.errors)
         # If there is no exception view, we also see request validation errors here
         except ResponseValidationError:
-            exc_info = sys.exc_info()
-            try:
-                response = request.invoke_exception_view(exc_info)
-            except HTTPNotFound:
-                reraise(*exc_info)
-            finally:
-                del exc_info
-            return response
+            return request.invoke_exception_view(reraise=True)
         return response
 
     return excview_tween

--- a/pyramid_openapi3/tween.py
+++ b/pyramid_openapi3/tween.py
@@ -32,13 +32,12 @@ def response_tween_factory(handler, registry) -> t.Callable[[Request], Response]
                 # not an openapi view or response validation not requested
                 return response
             # validate response
-            open_request = PyramidOpenAPIRequest(request)
-            open_response = PyramidOpenAPIResponse(response)
+            openapi_request = PyramidOpenAPIRequest.create(request)
+            openapi_response = PyramidOpenAPIResponse.create(response)
             settings = request.registry.settings["pyramid_openapi3"]
             result = settings["response_validator"].validate(
-                request=open_request, response=open_response
+                request=openapi_request, response=openapi_response
             )
-
             if result.errors:
                 raise ResponseValidationError(errors=result.errors)
         # If there is no exception view, we also see request validation errors here

--- a/pyramid_openapi3/wrappers.py
+++ b/pyramid_openapi3/wrappers.py
@@ -1,76 +1,51 @@
 """Wrap Pyramid's Request and Response."""
 
-from openapi_core.wrappers.base import BaseOpenAPIRequest
-from openapi_core.wrappers.base import BaseOpenAPIResponse
+from openapi_core.validation.request.datatypes import OpenAPIRequest
+from openapi_core.validation.request.datatypes import RequestParameters
+from openapi_core.validation.response.datatypes import OpenAPIResponse
 from pyramid.request import Request
 from pyramid.response import Response
+from urllib.parse import urljoin
 
 import typing as t
 
 
-class PyramidOpenAPIRequest(BaseOpenAPIRequest):
-    def __init__(self, request: Request) -> None:
-        self.request = request
+class PyramidOpenAPIRequest:
+    @classmethod
+    def create(
+        cls: t.Type["PyramidOpenAPIRequest"], request: Request
+    ) -> "OpenAPIRequest":
+        """Create OpenAPIRequest from Pyramid Request."""
+        method = request.method.lower()
+        path_pattern = (
+            request.matched_route.pattern if request.matched_route else request.path
+        )
 
-    @property
-    def host_url(self) -> str:
-        """Map openapi_core's host_url to pyramid's host_url."""
-        return self.request.host_url
+        parameters = RequestParameters(
+            path=request.matchdict,
+            query=request.GET,
+            header=request.headers,
+            cookie=request.cookies,
+        )
+        full_url_pattern = urljoin(request.host_url, path_pattern)
 
-    @property
-    def path(self) -> str:
-        """Map openapi_core's path to pyramid's path."""
-        return self.request.path
-
-    @property
-    def method(self) -> str:
-        """Map openapi_core's methor to pyramid's method."""
-        return self.request.method.lower()
-
-    @property
-    def path_pattern(self) -> str:
-        """Map openapi_core's path_pattern to pyramid's path_pattern."""
-        if self.request.matched_route:
-            return self.request.matched_route.pattern
-        else:
-            return self.path
-
-    @property
-    def parameters(self) -> t.Dict:
-        """Map openapi_core's parameters to pyramid's request info."""
-        return {
-            "path": self.request.matchdict,
-            "query": self.request.GET,
-            "header": self.request.headers,
-            "cookie": self.request.cookies,
-        }
-
-    @property
-    def body(self) -> str:
-        """Map openapi_core's body to pyramid's body."""
-        return self.request.body
-
-    @property
-    def mimetype(self) -> str:
-        """Map openapi_core's mimetype to pyramid's content_type."""
-        return self.request.content_type
+        return OpenAPIRequest(
+            full_url_pattern=full_url_pattern,
+            method=method,
+            parameters=parameters,
+            body=request.body,
+            mimetype=request.content_type,
+        )
 
 
-class PyramidOpenAPIResponse(BaseOpenAPIResponse):
-    def __init__(self, response: Response):
-        self.response = response
-
-    @property
-    def data(self) -> bytes:
-        """Map openapi_core's data to pyramid's body."""
-        return self.response.body
-
-    @property
-    def status_code(self) -> int:
-        """Map openapi_core's status_code to pyramid's status_code."""
-        return self.response.status_code
-
-    @property
-    def mimetype(self) -> str:
-        """Map openapi_core's mimetype to pyramid's content_type."""
-        return self.response.content_type
+class PyramidOpenAPIResponse:
+    @classmethod
+    def create(
+        cls: t.Type["PyramidOpenAPIResponse"], response: Response
+    ) -> "OpenAPIResponse":
+        """Create OpenAPIResponse from Pyramid Response."""
+        return OpenAPIResponse(
+            data=response.body,
+            status_code=response.status_code,
+            mimetype=response.content_type,
+        )

--- a/pyramid_openapi3/wrappers.py
+++ b/pyramid_openapi3/wrappers.py
@@ -10,10 +10,10 @@ from urllib.parse import urljoin
 import typing as t
 
 
-class PyramidOpenAPIRequest:
+class PyramidOpenAPIRequestFactory:
     @classmethod
     def create(
-        cls: t.Type["PyramidOpenAPIRequest"], request: Request
+        cls: t.Type["PyramidOpenAPIRequestFactory"], request: Request
     ) -> "OpenAPIRequest":
         """Create OpenAPIRequest from Pyramid Request."""
         method = request.method.lower()
@@ -38,10 +38,10 @@ class PyramidOpenAPIRequest:
         )
 
 
-class PyramidOpenAPIResponse:
+class PyramidOpenAPIResponseFactory:
     @classmethod
     def create(
-        cls: t.Type["PyramidOpenAPIResponse"], response: Response
+        cls: t.Type["PyramidOpenAPIResponseFactory"], response: Response
     ) -> "OpenAPIResponse":
         """Create OpenAPIResponse from Pyramid Response."""
         return OpenAPIResponse(

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,5 +22,8 @@ ignore_missing_imports = True
 [mypy-pytest.*]
 ignore_missing_imports = True
 
+[mypy-webtest.*]
+ignore_missing_imports = True
+
 [mypy-zope.interface.*]
 ignore_missing_imports = True

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open(os.path.join(here, "CHANGELOG.md"), encoding="utf-8") as f:
     long_description += "\n\n" + f.read()
 
 
-VERSION = "0.5.0-beta.2"
+VERSION = "0.5.0-beta.3"
 
 
 class VerifyVersionCommand(install):

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open(os.path.join(here, "CHANGELOG.md"), encoding="utf-8") as f:
     long_description += "\n\n" + f.read()
 
 
-VERSION = "0.4.1"
+VERSION = "0.5.0-beta.1"
 
 
 class VerifyVersionCommand(install):
@@ -68,6 +68,6 @@ setup(
     keywords="pyramid openapi3 openapi rest restful",
     packages=find_packages(exclude=["tests"]),
     package_data={"pyramid_openapi3": ["static/*.*"], "": ["LICENSE"]},
-    install_requires=["openapi-core<0.12.0", "openapi-spec-validator", "pyramid"],
+    install_requires=["openapi-core", "openapi-spec-validator", "pyramid"],
     cmdclass={"verify": VerifyVersionCommand},
 )

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ with open(os.path.join(here, "CHANGELOG.md"), encoding="utf-8") as f:
     long_description += "\n\n" + f.read()
 
 
-VERSION = "0.5.0-beta.1"
+VERSION = "0.5.0-beta.2"
 
 
 class VerifyVersionCommand(install):


### PR DESCRIPTION
The `openapi-core` library we build on top of is upgraded to `0.13.2`
which brings a complete rewrite of the validation mechanism that is now
based on `jsonschema` library. This manifests as different validation error messages.

Additionally, I moved `openapi_validation_error` from `examples/todoapp` into the main package so it becomes a first-class citizen and people can use it without copy/pasting. If you need custom JSON rendering, you can provide your own `extract_error` function via `pyramid_openapi3_extract_error` config setting.

This is how a migration to this new version looks like in a "realworld app": https://github.com/niteoweb/pyramid-realworld-example-app/pull/90

Closes https://github.com/Pylons/pyramid_openapi3/pull/59
Closes https://github.com/Pylons/pyramid_openapi3/pull/33
Closes https://github.com/Pylons/pyramid_openapi3/pull/43
Closes https://github.com/Pylons/pyramid_openapi3/issues/40
Closes https://github.com/Pylons/pyramid_openapi3/issues/34
Closes https://github.com/Pylons/pyramid_openapi3/issues/35
Refs https://github.com/p1c2u/openapi-core/issues/160