### PR TITLE
Bad JWT tokens should result in 401 instead of 400.

### DIFF
--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -5,6 +5,7 @@ from .exceptions import RequestValidationError
 from .exceptions import ResponseValidationError
 from .wrappers import PyramidOpenAPIRequestFactory
 from openapi_core import create_spec
+from openapi_core.validation.exceptions import InvalidSecurity
 from openapi_core.validation.request.validators import RequestValidator
 from openapi_core.validation.response.validators import ResponseValidator
 from openapi_spec_validator import validate_spec
@@ -191,6 +192,10 @@ def openapi_validation_error(
     # validation failed for response, it is our fault (-> 500)
     if isinstance(context, RequestValidationError):
         status_code = 400
+        for error in context.errors:
+            if isinstance(error, InvalidSecurity):
+                status_code = 401
+
     if isinstance(context, ResponseValidationError):
         status_code = 500
 

--- a/pyramid_openapi3/tests/test_extract_errors.py
+++ b/pyramid_openapi3/tests/test_extract_errors.py
@@ -405,6 +405,34 @@ class BadRequestsTests(unittest.TestCase):
             },
         ]
 
+    def test_bad_JWT_token(self) -> None:
+        """Render 401 on bad JWT token."""
+        endpoints = """
+          /foo:
+            get:
+              security:
+                - Token:
+                    []
+              responses:
+                200:
+                  description: Say hello
+                401:
+                  description: Unauthorized
+        components:
+          securitySchemes:
+            Token:
+              type: apiKey
+              name: Authorization
+              in: header
+        """
+        res = self._testapp(view=self.foo, endpoints=endpoints).get("/foo", status=401)
+        assert res.json == [
+            {
+                "exception": "InvalidSecurity",
+                "message": "Security not valid for any requirement",
+            }
+        ]
+
 
 class BadResponsesTests(unittest.TestCase):
     """A suite of tests that make sure bad responses are prevented."""


### PR DESCRIPTION
It's better to be more specific.