### PR TITLE
pass the response into the response validation exception

### DIFF
--- a/pyramid_openapi3/exceptions.py
+++ b/pyramid_openapi3/exceptions.py
@@ -28,8 +28,9 @@ class ResponseValidationError(HTTPInternalServerError):
 
     explanation = "Response validation failed."
 
-    def __init__(self, *args, errors, **kwargs) -> None:
+    def __init__(self, *args, response, errors, **kwargs) -> None:
         super().__init__(*args, **kwargs)
+        self.response = response
         self.errors = errors
         self.detail = self.message = "\n".join(str(e) for e in errors)
 

--- a/pyramid_openapi3/tween.py
+++ b/pyramid_openapi3/tween.py
@@ -36,7 +36,9 @@ def response_tween_factory(handler, registry) -> t.Callable[[Request], Response]
                 request=openapi_request, response=openapi_response
             )
             if result.errors:
-                raise ResponseValidationError(errors=result.errors)
+                raise ResponseValidationError(
+                    response=response, errors=result.errors,
+                )
         # If there is no exception view, we also see request validation errors here
         except ResponseValidationError:
             return request.invoke_exception_view(reraise=True)


### PR DESCRIPTION
Support use-cases where we can return the response but log the errors,
or at least inspect the actual generated response.