### PR TITLE
docs: Fix simple typo, opeanapi -> openapi

### DIFF
--- a/examples/singlefile/app.py
+++ b/examples/singlefile/app.py
@@ -112,7 +112,7 @@ class FunctionalTests(unittest.TestCase):
         the servers fault to generate an invalid response.
 
         This is to prevent us from forgetting to define all possible responses
-        in our opeanapi document.
+        in our openapi document.
         """
         res = self.testapp.get("/hello?name=admin", status=500)
         self.assertIn("Unknown response http status: 403", res.text)


### PR DESCRIPTION
There is a small typo in examples/singlefile/app.py.

Should read `openapi` rather than `opeanapi`.

