### PR TITLE
Response validation errors should be logged as errors

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,6 @@
 # Use shell.nix to build the development environment
-use nix
+if [ -x "$(command -v lorri)" ]; then
+  eval "$(lorri direnv)"
+else
+  use nix
+fi

--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -185,9 +185,9 @@ def openapi_validation_error(
 ) -> Response:
     """Render any validation errors as JSON."""
     if isinstance(context, RequestValidationError):
-        logger.info(context)
+        logger.warning(context)
     if isinstance(context, ResponseValidationError):
-        logger.warn(context)
+        logger.error(context)
 
     extract_errors = request.registry.settings["pyramid_openapi3_extract_errors"]
     errors = list(extract_errors(request, context.errors))

--- a/pyramid_openapi3/tests/test_validation.py
+++ b/pyramid_openapi3/tests/test_validation.py
@@ -145,7 +145,7 @@ class TestRequestValidation(TestCase):
             "HTTP_ACCEPT": "application/json",
         }
         start_response = DummyStartResponse()
-        with self.assertLogs(level="INFO") as cm:
+        with self.assertLogs(level="WARNING") as cm:
             response = router(environ, start_response)
 
         self.assertEqual(start_response.status, "400 Bad Request")
@@ -160,7 +160,7 @@ class TestRequestValidation(TestCase):
             ],
         )
         self.assertEqual(
-            cm.output, ["INFO:pyramid_openapi3:Missing required parameter: bar"]
+            cm.output, ["WARNING:pyramid_openapi3:Missing required parameter: bar"]
         )
 
     def test_response_validation_error(self) -> None:
@@ -186,7 +186,7 @@ class TestRequestValidation(TestCase):
             "QUERY_STRING": "bar=1",
         }
         start_response = DummyStartResponse()
-        with self.assertLogs(level="WARN") as cm:
+        with self.assertLogs(level="ERROR") as cm:
             response = router(environ, start_response)
         self.assertEqual(start_response.status, "500 Internal Server Error")
         self.assertEqual(
@@ -199,7 +199,7 @@ class TestRequestValidation(TestCase):
             ],
         )
         self.assertEqual(
-            cm.output, ["WARNING:pyramid_openapi3:Unknown response http status: 412"]
+            cm.output, ["ERROR:pyramid_openapi3:Unknown response http status: 412"]
         )
 
     def test_nonapi_view(self) -> None:


### PR DESCRIPTION
Because they are most likely errors in the source code.

Response validation errors should be logged as warnings, so we
notice them and potentially help people that have problems using our API.