### PR TITLE
Pass an ItemsView of headers to RequestParameters

### DIFF
--- a/pyramid_openapi3/wrappers.py
+++ b/pyramid_openapi3/wrappers.py
@@ -29,7 +29,7 @@ class PyramidOpenAPIRequestFactory:
         parameters = RequestParameters(
             path=request.matchdict,
             query=request.GET,
-            header=request.headers,
+            header=request.headers.items(),
             cookie=request.cookies,
         )
 


### PR DESCRIPTION
This is adds compatibility with the manner in which werkzeug Headers will treat this value.