### PR TITLE
Raise a warning when request validation causes a response validation failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## Changelog
 
+0.8.2 (Unreleased)
+------------------
+
+* Raise a warning when a bad API spec causes validation errors to be discarded.
+  [matthewwilkes]
+
 0.8.1 (2020-05-03)
 ------------------
 

--- a/pyramid_openapi3/exceptions.py
+++ b/pyramid_openapi3/exceptions.py
@@ -50,6 +50,10 @@ class InvalidCustomFormatterValue(InvalidSchemaFormatValue):
         return str(self.original_exception)
 
 
+class ImproperAPISpecificationWarning(UserWarning):
+    """A warning that an end-user's API specification has a problem."""
+
+
 def extract_errors(
     request: Request, errors: t.List[OpenAPIError]
 ) -> t.Iterator[t.Dict[str, str]]:


### PR DESCRIPTION
The request validator can raise a 400 error if the incoming request fails
the validation implied by the spec. If the spec does not allow a matching
400 response from this endpoint, that error will be lost and replaced with
a validation error for a bad response code. While we already log the relevant
information, this adds a warning to explicitly alert programmers that they
have erred with their API specification.

This was inspired by #49 and causes the following output from pytest if you write a test that hits this edge case:

```
pyramid_openapi3/tests/test_validation.py::TestImproperAPISpecValidation::test_request_validation_error_causes_response_validation_error
  /tmp/tmpbbfc55gb:0: ImproperAPISpecificationWarning: Discarding 400 Bad Request validation error with body [{"exception":"MissingRequiredParameter","message":"Missing required parameter: bar","field":"bar"}] as it is not a valid response for GET to /foo (foo)
```

Other test runners may not show the warning, but I think this is an improvement.

Note: The push pre-commit step segfaulted for me. The individual commit ones worked fine, so I think it's okay, but I wanted to flag this.