### PR TITLE
Test minimal supported version of openapi-core

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,14 +43,12 @@ jobs:
       - checkout
 
       - run:
-          name: Prepare cache key
-          command: python --version > python_version.txt
+          name: Test minimal openapi-core version on Python 3.7
+          command: ./inject_minimal_openapi-core.sh
 
       - restore_cache:
           keys:
-            - v5-dependencies-{{ checksum "python_version.txt" }}-{{ checksum "Pipfile.lock" }}
-            # fallback to using the latest cache if no exact match is found
-            - v5-dependencies-{{ checksum "python_version.txt" }}
+            - v1-dependencies-{{ checksum "Pipfile.lock" }}
 
       - run:
           name: install dependencies
@@ -62,7 +60,7 @@ jobs:
       - save_cache:
           paths:
             - ./.venv
-          key: v5-dependencies-{{ checksum "python_version.txt" }}-{{ checksum "Pipfile.lock" }}
+          key: v1-dependencies-{{ checksum "Pipfile.lock" }}
 
       - run:
           name: run tests
@@ -94,15 +92,9 @@ jobs:
     steps:
       - checkout
 
-      - run:
-          name: Prepare cache key
-          command: python --version > python_version.txt
-
       - restore_cache:
           keys:
-            - v5-dependencies-{{ checksum "python_version.txt" }}-{{ checksum "Pipfile.lock" }}
-            # fallback to using the latest cache if no exact match is found
-            - v5-dependencies-{{ checksum "python_version.txt" }}
+            - v1-dependencies-{{ checksum "Pipfile.lock" }}
 
       - run:
           name: install dependencies
@@ -115,7 +107,7 @@ jobs:
       - save_cache:
           paths:
             - ./.venv
-          key: v5-dependencies-{{ checksum "python_version.txt" }}-{{ checksum "Pipfile.lock" }}
+          key: v1-dependencies-{{ checksum "Pipfile.lock" }}
 
       - run:
           name: verify git tag vs. version

--- a/inject_minimal_openapi-core.sh
+++ b/inject_minimal_openapi-core.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# This script is to be used in CircleCI to run tests against the minimal
+# supported version of openapi-core.
+#
+# It replaces the latest version of openapi-core (and its hash) in Pipfile.lock
+# file with the minimal supported version. It fails with exit code 1 if
+# the latest version (and its hash) were updated in Pipfile.lock and not
+# changed here in this script.
+
+set -e
+
+if [[ $(python --version) =~ 3\.7 ]]; then
+    echo "Replacing the openapi-core version in Pipfile.lock with the minimal supported version"
+
+    grep "==0.13.3" Pipfile.lock
+    sed -i 's/"==0.13.3"/"==0.13.1"/g' Pipfile.lock
+
+    grep "57973b7383214a529012cf65ddac8c22b25a4df497366e588e88c627581c2928" Pipfile.lock
+    sed -i s/57973b7383214a529012cf65ddac8c22b25a4df497366e588e88c627581c2928/d61305484f8fefda78fdddaf8890af6804fae99dff94013abd9480873880bddc/g Pipfile.lock
+fi

--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,6 @@ setup(
     keywords="pyramid openapi3 openapi rest restful",
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
-    install_requires=["openapi-core", "openapi-spec-validator", "pyramid"],
+    install_requires=["openapi-core>=0.13.1", "openapi-spec-validator", "pyramid"],
     cmdclass={"verify": VerifyVersionCommand},
 )


### PR DESCRIPTION
1. Set the minimal supported version of openapi-core in setup.py
2. Hack CircleCI to test the minimal supported version in the Python 3.7 job

Closes #74