### PR TITLE
Add the ability to toggle request/response validation independently

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,19 @@ def myview(request):
 For requests, `request.openapi_validated` is available with two fields: `parameters` and `body`.
 For responses, if the payload does not match the API document, an exception is raised.
 
+## Advanced configuration
+
+If you would like to disable request / response validation, you can do so by adjusting either of the following options (you can also set them in your `.ini` if you prefer)
+
+```python
+config.registry.settings["pyramid_openapi3.enable_request_validation"] = False
+config.registry.settings["pyramid_openapi3.enable_response_validation"] = False
+```
+
+These values default to `True` if they are not present.
+
+> **Warning:**
+Disabling request validation will result in `request.openapi_validated` no longer being available to use.
 
 ## Demo / Examples
 

--- a/pyramid_openapi3/tween.py
+++ b/pyramid_openapi3/tween.py
@@ -36,8 +36,9 @@ def response_tween_factory(handler, registry) -> t.Callable[[Request], Response]
             result = settings["response_validator"].validate(
                 request=openapi_request, response=openapi_response
             )
+            request_validated = request.environ.get("pyramid_openapi3.validate_request")
             if result.errors:
-                if request.openapi_validated.errors:
+                if request_validated and request.openapi_validated.errors:
                     warnings.warn_explicit(
                         ImproperAPISpecificationWarning(
                             "Discarding {response.status} validation error with body "


### PR DESCRIPTION
- Allow the user to toggle request/response validation independently of each other
    - They can do this by optionally setting one/or both of these settings:
    ```python
    config.registry.settings["pyramid_openapi3.enable_request_validation"] = False
    config.registry.settings["pyramid_openapi3.enable_response_validation"] = False
    ```

closes #90 