### PR TITLE
Allow relative file $ref links in OpenApi spec

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,12 @@ jobs:
             cd examples/todoapp
             pipenv run python -m unittest tests.py
 
+      - run:
+          name: run tests for the splitfile example
+          command: |
+            cd examples/splitfile
+            pipenv run python -m unittest tests.py
+
       - store_artifacts:
           path: htmlcov
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Disabling request validation will result in `request.openapi_validated` no longe
 There are three examples provided with this package:
 * A fairly simple [single-file app providing a Hello World API](https://github.com/Pylons/pyramid_openapi3/tree/master/examples/singlefile).
 * A slightly more [built-out app providing a TODO app API](https://github.com/Pylons/pyramid_openapi3/tree/master/examples/todoapp).
-* A TODO app API [containing a multifile yaml spec](https://github.com/Pylons/pyramid_openapi3/tree/master/examples/splitfile) (relative file `$ref`)
+* Another TODO app API, defined using a [YAML spec split into multiple files](https://github.com/Pylons/pyramid_openapi3/tree/master/examples/splitfile).
 
 Both examples come with tests that exhibit pyramid_openapi's error handling and validation capabilities.
 

--- a/README.md
+++ b/README.md
@@ -79,6 +79,24 @@ For responses, if the payload does not match the API document, an exception is r
 
 ## Advanced configuration
 
+### Relative File References in Spec
+
+A feature introduced in OpenApi3 is the ability to use `$ref` links to external files (https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#referenceObject).
+
+In order to use this you must ensure that you have all of your spec files in a given directory (ensure that you do not have any code in this directory as all the files in it are exposed as static files), then **replace** the `pyramid_openapi3_spec` call that you did in [Getting Started](#getting-started) with the following:
+
+```python
+config.pyramid_openapi3_spec_directory('path/to/openapi.yaml', route='/api/v1/spec')
+```
+
+Some notes:
+
+- Do not set the `route` of your `pyramid_openapi3_spec_directory` to the same value as the `route` of `pyramid_openapi3_add_explorer`.
+- The `route` that you set for `pyramid_openapi3_spec_directory` should not contain any file extensions as this becomes the root for all of the files in your specified `filepath`.
+- You cannot use `pyramid_openapi3_spec_directory` and `pyramid_openapi3_spec` in the same app.
+
+### Toggle Request / Response Validation
+
 If you would like to disable request / response validation, you can do so by adjusting either of the following options (you can also set them in your `.ini` if you prefer)
 
 ```python
@@ -93,9 +111,10 @@ Disabling request validation will result in `request.openapi_validated` no longe
 
 ## Demo / Examples
 
-There are two examples provided with this package:
+There are three examples provided with this package:
 * A fairly simple [single-file app providing a Hello World API](https://github.com/Pylons/pyramid_openapi3/tree/master/examples/singlefile).
 * A slightly more [built-out app providing a TODO app API](https://github.com/Pylons/pyramid_openapi3/tree/master/examples/todoapp).
+* A TODO app API [containing a multifile yaml spec](https://github.com/Pylons/pyramid_openapi3/tree/master/examples/splitfile) (relative file `$ref`)
 
 Both examples come with tests that exhibit pyramid_openapi's error handling and validation capabilities.
 

--- a/examples/splitfile/README.md
+++ b/examples/splitfile/README.md
@@ -1,0 +1,39 @@
+# An example RESTful API app showcasing the power of pyramid_openapi3
+
+This folder showcases how to use the [pyramid_openapi3](https://github.com/Pylons/pyramid_openapi3) Pyramid add-on for building robust RESTful APIs. With only a few lines of code you get automatic validation of requests and responses against an OpenAPI v3 schema, along with Swagger "try-it-out" documentation for your API.
+
+## How to run
+
+```bash
+$ git clone https://github.com/Pylons/pyramid_openapi3.git
+$ cd pyramid_openapi3/examples/splitfile
+$ virtualenv -p python3.8 .
+$ source bin/activate
+$ pip install pyramid_openapi3
+$ python app.py
+```
+
+Then use the Swagger interface at http://localhost:6543/docs/ to discover the API. Use the `Try it out` button to run through a few request/response scenarios.
+
+For example:
+* Get all TODO items using the GET request.
+* Adding a new TODO item using the POST request.
+* Getting a 400 BadRequest response for an empty POST request
+* Getting a 400 BadRequest response for a POST request when `title` is too long (over 40 characters).
+
+All of these examples are covered with tests that you can run with `$ python -m unittest tests.py`. The tests need the Python webtest module installed. If your virtualenv is still activated you can install it with `pip install webtest`.
+
+
+## Further read
+
+* A slightly simpler, multi-file (single spec file) example is available in the [`examples/todoapp`](https://github.com/Pylons/pyramid_openapi3/tree/master/examples/todoapp) folder.
+
+* A simpler, single-file (spec in app) example is available in the [`examples/singlefile`](https://github.com/Pylons/pyramid_openapi3/tree/master/examples/singlefile) folder.
+
+* A fully built-out app, with 100% test coverage, providing a [RealWorld.io](https://realworld.io) API is available at [niteoweb/pyramid-realworld-example-app](https://github.com/niteoweb/pyramid-realworld-example-app). It is a Heroku-deployable Pyramid app that provides an API for a Medium.com-like social app. You are encouraged to use it as a scaffold for your next project.
+
+* More information about the library providing the integration between OpenAPI specs and Pyramid, more advanced features and design defence, is available in the main [README](https://github.com/Pylons/pyramid_openapi3) file.
+
+* More validators for fields are listed in the [OpenAPI Specification](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#properties) document. You can use Regex as well.
+
+* For an idea of a fully-fledged production OpenApi specification, check out [WooCart's OpenAPI docs](https://app.woocart.com/api/v1/).

--- a/examples/splitfile/README.md
+++ b/examples/splitfile/README.md
@@ -1,6 +1,6 @@
 # An example RESTful API app showcasing how to split YAML spec into multiple files
 
-This folder showcases how to use the [pyramid_openapi3](https://github.com/Pylons/pyramid_openapi3) Pyramid add-on for building robust RESTful APIs defined with a multi-file YAML schema.```
+This folder showcases how to use the [pyramid_openapi3](https://github.com/Pylons/pyramid_openapi3) Pyramid add-on for building robust RESTful APIs defined with a multi-file YAML schema.
 
 ## How to run
 

--- a/examples/splitfile/README.md
+++ b/examples/splitfile/README.md
@@ -1,6 +1,6 @@
-# An example RESTful API app showcasing the power of pyramid_openapi3
+# An example RESTful API app showcasing how to split YAML spec into multiple files
 
-This folder showcases how to use the [pyramid_openapi3](https://github.com/Pylons/pyramid_openapi3) Pyramid add-on for building robust RESTful APIs. With only a few lines of code you get automatic validation of requests and responses against an OpenAPI v3 schema, along with Swagger "try-it-out" documentation for your API.
+This folder showcases how to use the [pyramid_openapi3](https://github.com/Pylons/pyramid_openapi3) Pyramid add-on for building robust RESTful APIs defined with a multi-file YAML schema.```
 
 ## How to run
 

--- a/examples/splitfile/app.py
+++ b/examples/splitfile/app.py
@@ -1,7 +1,7 @@
-"""A Todo-app implementation using pyramid_openapi3.
+"""A Todo-app implementation using pyramid_openapi3 and YAML spec split into multiple files.
 
 See README.md at
-https://github.com/Pylons/pyramid_openapi3/tree/master/examples/todoapp
+https://github.com/Pylons/pyramid_openapi3/tree/master/examples/splitfile
 """
 
 from dataclasses import dataclass

--- a/examples/splitfile/app.py
+++ b/examples/splitfile/app.py
@@ -1,0 +1,72 @@
+"""A Todo-app implementation using pyramid_openapi3.
+
+See README.md at
+https://github.com/Pylons/pyramid_openapi3/tree/master/examples/todoapp
+"""
+
+from dataclasses import dataclass
+from pyramid.config import Configurator
+from pyramid.request import Request
+from pyramid.router import Router
+from pyramid.view import view_config
+from wsgiref.simple_server import make_server
+
+import os
+import typing as t
+
+
+@dataclass
+class Item:
+    """A single TODO item."""
+
+    title: str
+
+    def __json__(self, request: Request) -> t.Dict[str, str]:
+        """JSON-renderer for this object."""
+        return {"title": self.title}
+
+
+# fmt: off
+# Poor-man's in-memory database. Pre-populated with three TODO items.
+ITEMS = [
+    Item(title="Buy milk"),
+    Item(title="Buy eggs"),
+    Item(title="Make pankaces!"),
+]
+# fmt: on
+
+
+@view_config(route_name="todo", renderer="json", request_method="GET", openapi=True)
+def get(request: Request) -> t.List[Item]:
+    """Serve the list of TODO items for GET requests."""
+    return ITEMS
+
+
+@view_config(route_name="todo", renderer="json", request_method="POST", openapi=True)
+def post(request: Request) -> str:
+    """Handle POST requests and create TODO items."""
+    item = Item(title=request.openapi_validated.body["title"])
+    ITEMS.append(item)
+    return "Item added."
+
+
+def app() -> Router:
+    """Prepare a Pyramid app."""
+    with Configurator() as config:
+        config.include("pyramid_openapi3")
+        config.add_static_view(name="spec", path="spec")
+        config.pyramid_openapi3_spec_directory(
+            os.path.join(os.path.dirname(__file__), "spec/openapi.yaml"),
+        )
+        config.pyramid_openapi3_add_explorer()
+        config.add_route("todo", "/")
+        config.scan(".")
+
+        return config.make_wsgi_app()
+
+
+if __name__ == "__main__":
+    """If app.py is called directly, start up the app."""
+    print("Swagger UI available at http://0.0.0.0:6543/docs/")  # noqa: T001
+    server = make_server("0.0.0.0", 6543, app())
+    server.serve_forever()

--- a/examples/splitfile/spec/openapi.yaml
+++ b/examples/splitfile/spec/openapi.yaml
@@ -1,0 +1,21 @@
+openapi: "3.0.0"
+
+info:
+  version: "1.0.0"
+  title: A simple Todo app API
+
+paths:
+  /:
+    $ref: "paths.yaml#/todos"
+
+components:
+  schemas:
+    Item:
+      $ref: "schemas.yaml#/Item"
+
+    Error:
+      $ref: "schemas.yaml#/Error"
+
+  responses:
+    ValidationError:
+      $ref: "responses.yaml#/ValidationError"

--- a/examples/splitfile/spec/paths.yaml
+++ b/examples/splitfile/spec/paths.yaml
@@ -1,0 +1,36 @@
+todos:
+  get:
+    summary: List of my TODO items
+    responses:
+      '200':
+        description: A list of my TODO items
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "schemas.yaml#/Item"
+
+  post:
+    summary: Create a TODO item
+    operationId: todo.create
+    requestBody:
+      required: true
+      description: Data for creating a new TODO item
+      content:
+        application/json:
+          schema:
+            $ref: schemas.yaml#/Item
+
+    responses:
+      '200':
+        description: Success message.
+        content:
+          application/json:
+            schema:
+              type: string
+
+      '400':
+        $ref: responses.yaml#/ValidationError
+      '500':
+        $ref: responses.yaml#/ValidationError

--- a/examples/splitfile/spec/responses.yaml
+++ b/examples/splitfile/spec/responses.yaml
@@ -1,0 +1,8 @@
+ValidationError:
+  description: OpenAPI request/response validation failed
+  content:
+    application/json:
+      schema:
+        type: array
+        items:
+          $ref: "schemas.yaml#/Error"

--- a/examples/splitfile/spec/schemas.yaml
+++ b/examples/splitfile/spec/schemas.yaml
@@ -1,0 +1,20 @@
+Item:
+  type: object
+  required:
+    - title
+  properties:
+    title:
+      type: string
+      maxLength: 40
+
+Error:
+  type: object
+  required:
+    - message
+  properties:
+    field:
+      type: string
+    message:
+      type: string
+    exception:
+      type: string

--- a/examples/splitfile/tests.py
+++ b/examples/splitfile/tests.py
@@ -1,4 +1,4 @@
-"""A couple of functional tests to showcase pyramid_openapi3 features."""
+"""A couple of functional tests to showcase pyramid_openapi3 works with YAML spec split into multiple files."""
 
 from unittest import mock
 from webtest import TestApp

--- a/examples/splitfile/tests.py
+++ b/examples/splitfile/tests.py
@@ -1,0 +1,89 @@
+"""A couple of functional tests to showcase pyramid_openapi3 features."""
+
+from unittest import mock
+from webtest import TestApp
+
+import app
+import unittest
+
+
+class TestHappyPath(unittest.TestCase):
+    """A suite of tests that make "happy path" requests against the app."""
+
+    def setUp(self) -> None:
+        """Start up the app so that tests can send requests to it."""
+        self.testapp = TestApp(app.app())
+
+    def test_list_todos(self) -> None:
+        """Root returns a list of TODOs."""
+        res = self.testapp.get("/", status=200)
+        self.assertEqual(
+            res.json,
+            [{"title": "Buy milk"}, {"title": "Buy eggs"}, {"title": "Make pankaces!"}],
+        )
+
+    def test_add_todo(self) -> None:
+        """POSTing to root saves a TODO."""  # noqa: D403
+        res = self.testapp.post_json("/", {"title": "Add marmalade"}, status=200)
+        self.assertEqual(res.json, "Item added.")
+
+        # clean up after the test by removing the "Add marmalade" item
+        app.ITEMS.pop()
+
+
+class TestBadRequests(TestHappyPath):
+    """A suite of tests that showcase out-of-the-box handling of bad requests."""
+
+    def test_empty_POST(self) -> None:
+        """Get a nice validation error when sending an empty POST request."""
+        res = self.testapp.post_json("/", {}, status=400)
+        self.assertEqual(
+            res.json,
+            [
+                {
+                    "exception": "ValidationError",
+                    "field": "title",
+                    "message": "'title' is a required property",
+                }
+            ],
+        )
+
+    def test_title_too_long(self) -> None:
+        """Get a nice validation error when title is too long."""
+        res = self.testapp.post_json("/", {"title": "a" * 41}, status=400)
+        self.assertEqual(
+            res.json,
+            [
+                {
+                    "exception": "ValidationError",
+                    "field": "title",
+                    "message": "'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' is too long",
+                }
+            ],
+        )
+
+
+class TestBadResponses(TestHappyPath):
+    """A suite of tests that showcase out-of-the-box handling of bad responses."""
+
+    def test_bad_items(self) -> None:
+        """Test bad output from view.
+
+        If our view returns JSON that does not match openapi.yaml schema,
+        then we should render a 500 error.
+        """
+        with mock.patch("app.ITEMS", ["foo", "bar"]):
+            res = self.testapp.get("/", status=500)
+        self.assertEqual(
+            res.json,
+            [
+                {
+                    "exception": "ValidationError",
+                    "message": "'foo' is not of type object",
+                },
+                {
+                    "exception": "ValidationError",
+                    "message": "'bar' is not of type object",
+                },
+            ],
+        )


### PR DESCRIPTION
## Description

- Create a new `add_spec_view_directory` directive
    - Allow you to split your openapi spec into multiple files (using the external file `$ref` links that came with OpenApi3).
    - You can test it by running the `app.py` located in `examples/splitfile`

Closes: #93 
