### PR TITLE
Validate all endpoints are handled

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,11 +95,18 @@ Some notes:
 - The `route` that you set for `pyramid_openapi3_spec_directory` should not contain any file extensions as this becomes the root for all of the files in your specified `filepath`.
 - You cannot use `pyramid_openapi3_spec_directory` and `pyramid_openapi3_spec` in the same app.
 
-### Toggle Request / Response Validation
+### Endpoints / Request / Response Validation
 
-If you would like to disable request / response validation, you can do so by adjusting either of the following options (you can also set them in your `.ini` if you prefer)
+pyramid-openapi3 offers builtin solutions to validate all endpoints are present on the
+app's codebase, accordingly to the OpenAPI specification, as well as validating every
+incoming/outgoing request and response.
+
+These features are enabled as a default, but if you would like to disable it, you can
+do so by adjusting either of the following options (you can also set them in your
+`.ini` config file, if you prefer)
 
 ```python
+config.registry.settings["pyramid_openapi3.enable_endpoint_validation"] = False
 config.registry.settings["pyramid_openapi3.enable_request_validation"] = False
 config.registry.settings["pyramid_openapi3.enable_response_validation"] = False
 ```

--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -1,6 +1,7 @@
 """Configure pyramid_openapi3 addon."""
 
 from .exceptions import extract_errors
+from .exceptions import MissingEndpointsError
 from .exceptions import RequestValidationError
 from .exceptions import ResponseValidationError
 from .wrappers import PyramidOpenAPIRequestFactory
@@ -14,6 +15,7 @@ from pathlib import Path
 from pyramid.config import Configurator
 from pyramid.config import PHASE0_CONFIG
 from pyramid.config.views import ViewDeriverInfo
+from pyramid.events import ApplicationCreated
 from pyramid.exceptions import ConfigurationError
 from pyramid.httpexceptions import exception_response
 from pyramid.path import AssetResolver
@@ -27,6 +29,7 @@ from string import Template
 import hupper
 import logging
 import typing as t
+import warnings
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +42,7 @@ def includeme(config: Configurator) -> None:
     config.add_directive("pyramid_openapi3_spec", add_spec_view)
     config.add_directive("pyramid_openapi3_spec_directory", add_spec_view_directory)
     config.add_tween("pyramid_openapi3.tween.response_tween_factory", over=EXCVIEW)
+    config.add_subscriber(check_all_routes, ApplicationCreated)
 
     if not config.registry.settings.get(  # pragma: no branch
         "pyramid_openapi3_extract_errors"
@@ -287,3 +291,31 @@ def openapi_validation_error(
         status_code = 500
 
     return exception_response(status_code, json_body=errors)
+
+
+def check_all_routes(event: ApplicationCreated):
+    """Assert all routes in the spec are defined on the app.
+
+    This handler method that listens for ApplicationCreated event and asserts
+    all routes defined on the spec have been registered
+    """
+
+    app = event.app
+    openapi_settings = app.registry.settings.get("pyramid_openapi3")
+    if not openapi_settings:
+        # pyramid_openapi3 not configured?
+        warnings.warn(
+            "pyramid_openapi3 settings not found. "
+            "Did you forget to call config.pyramid_openapi3_spec?"
+        )
+        return
+
+    if not openapi_settings.get("enable_endpoint_validation", True):
+        logger.debug("Endpoint validation against specification is disabled")
+        return
+    paths = list(openapi_settings["spec"].paths.keys())
+    routes = [route.path for name, route in app.routes_mapper.routes.items()]
+
+    missing = [r for r in paths if r not in routes]
+    if missing:
+        raise MissingEndpointsError(missing)

--- a/pyramid_openapi3/exceptions.py
+++ b/pyramid_openapi3/exceptions.py
@@ -129,3 +129,12 @@ def extract_errors(
             output.update({"field": field})
 
         yield output
+
+
+class MissingEndpointsError(Exception):
+    missing: list
+
+    def __init__(self, missing: t.List[str]) -> None:
+        self.missing = missing
+        message = f"Unable to find registered " f"routes or endpoints {missing}"
+        super(MissingEndpointsError, self).__init__(message)

--- a/pyramid_openapi3/tests/test_app_construction.py
+++ b/pyramid_openapi3/tests/test_app_construction.py
@@ -1,0 +1,126 @@
+"""Tests for app creation when using pyramid_openapi3."""
+from pyramid.config import Configurator
+from pyramid.request import Request
+from pyramid.testing import testConfig
+from pyramid_openapi3 import MissingEndpointsError
+
+import logging
+import pytest
+import tempfile
+import typing as t
+
+DOCUMENT = b"""
+    openapi: "3.0.0"
+    info:
+      version: "1.0.0"
+      title: Foo API
+    paths:
+      /foo:
+        get:
+          responses:
+            200:
+              description: A foo
+        post:
+          responses:
+            200:
+              description: A POST foo
+      /bar:
+        get:
+          responses:
+            200:
+              description: A bar
+"""
+
+
+def foo_view(request: Request) -> str:
+    """Return a dummy string."""
+    return "Foo"  # pragma: no cover
+
+
+def bar_view(request: Request) -> str:
+    """Return a dummy string."""
+    return "Bar"  # pragma: no cover
+
+
+@pytest.fixture
+def document() -> t.Generator[t.IO, None, None]:
+    """Load the DOCUMENT into a temp file."""
+    with tempfile.NamedTemporaryFile() as document:
+        document.write(DOCUMENT)
+        document.seek(0)
+
+        yield document
+
+
+@pytest.fixture
+def simple_config() -> Configurator:
+    """Config fixture."""
+    with testConfig() as config:
+        config.include("pyramid_openapi3")
+
+        yield config
+
+
+@pytest.fixture
+def app_config(
+    simple_config: Configurator, document: t.IO
+) -> t.Generator[Configurator, None, None]:
+    """Incremented fixture that loads the DOCUMENT above into the config."""
+    simple_config.pyramid_openapi3_spec(
+        document.name, route="/foo.yaml", route_name="foo_api_spec"
+    )
+    yield simple_config
+
+
+def test_all_routes(app_config: Configurator) -> None:
+    """Test case showing that an app can be created with all routes define."""
+    app_config.add_route(name="foo", pattern="/foo")
+    app_config.add_route(name="bar", pattern="/bar")
+    app_config.add_view(
+        foo_view, route_name="foo", renderer="string", request_method="OPTIONS"
+    )
+    app_config.add_view(
+        bar_view, route_name="bar", renderer="string", request_method="GET"
+    )
+
+    app_config.make_wsgi_app()
+
+
+def test_missing_routes(app_config: Configurator) -> None:
+    """Test case showing app creation fails, when define routes are missing."""
+    app_config.add_route(name="foo", pattern="/foo")
+    app_config.add_view(
+        foo_view, route_name="foo", renderer="string", request_method="GET"
+    )
+
+    with pytest.raises(MissingEndpointsError) as ex:
+        app_config.make_wsgi_app()
+
+    assert "/bar" in ex.value.missing
+
+
+def test_disable_endpoint_validation(app_config: Configurator, caplog) -> None:
+    """Test case showing app creation whilst disabling endpoint validation."""
+    caplog.set_level(logging.DEBUG)
+    app_config.registry.settings.get("pyramid_openapi3").setdefault(
+        "enable_endpoint_validation", False
+    )
+    app_config.add_route(name="foo", pattern="/foo")
+    app_config.add_view(
+        foo_view, route_name="foo", renderer="string", request_method="GET"
+    )
+
+    app_config.make_wsgi_app()
+
+    assert "Endpoint validation against specification is disabled" in caplog.text
+
+
+def test_unconfigured_app(simple_config: Configurator) -> None:
+    """Asserts the app can be created if no spec has been defined."""
+    simple_config.add_route(name="foo", pattern="/foo")
+    simple_config.add_view(
+        foo_view, route_name="foo", renderer="string", request_method="OPTIONS"
+    )
+
+    with pytest.warns(UserWarning, match="pyramid_openapi3 settings not found"):
+        simple_config.make_wsgi_app()


### PR DESCRIPTION
Proposed changes for #21. This was originally proposed on #37, but since it can no longer be re-opened, but creating this new PR.

This will listen for an event triggered by Pyramid once all configurations have been parsed and the App has been created.

At this point we're certain no new routes will be added to the config, so we can check whether all the routes in the spec have been registered on the application route map.

Here I raise an exception if any route is missing.