### PR TITLE
Fix for route validation when used with pyramid route_prefix_context

### DIFF
--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -325,6 +325,7 @@ def check_all_routes(event: ApplicationCreated):
             prefixes.append(path)
 
     def remove_prefixes(path):
+        path = f"/{path}" if not path.startswith("/") else path
         for prefix in prefixes:
             path = path.replace(prefix, "")
         return path

--- a/pyramid_openapi3/tests/test_app_construction.py
+++ b/pyramid_openapi3/tests/test_app_construction.py
@@ -103,6 +103,21 @@ def test_prefixed_routes(app_config: Configurator) -> None:
     app_config.make_wsgi_app()
 
 
+def test_pyramid_prefixed_context_routes(app_config: Configurator) -> None:
+    """Test case for prefixed routes using pyramid route_prefix_context."""
+    with app_config.route_prefix_context("/api/v1"):
+        app_config.add_route(name="foo", pattern="/foo")
+        app_config.add_route(name="bar", pattern="/bar")
+    app_config.add_view(
+        foo_view, route_name="foo", renderer="string", request_method="OPTIONS"
+    )
+    app_config.add_view(
+        bar_view, route_name="bar", renderer="string", request_method="GET"
+    )
+
+    app_config.make_wsgi_app()
+
+
 def test_missing_routes(app_config: Configurator) -> None:
     """Test case showing app creation fails, when defined routes are missing."""
     with pytest.raises(MissingEndpointsError) as ex:


### PR DESCRIPTION
# Description

- Fix route validation failing when `route_prefix_context` from `pyramid.config.Configurator` is used

fixes #100 