### PR TITLE
Allow setting permission for explorer and spec view.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Support for endpoint validation of prefixed routes.
   [zupo]
 
+* Allow setting permission for explorer and spec view.
+  [sweh]
+
 
 0.10.1 (2020-10-26)
 ------------------

--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -22,6 +22,7 @@ from pyramid.path import AssetResolver
 from pyramid.request import Request
 from pyramid.response import FileResponse
 from pyramid.response import Response
+from pyramid.security import NO_PERMISSION_REQUIRED
 from pyramid.settings import asbool
 from pyramid.tweens import EXCVIEW
 from string import Template
@@ -121,6 +122,7 @@ def add_explorer_view(
     route_name: str = "pyramid_openapi3.explorer",
     template: str = "static/index.html",
     ui_version: str = "3.17.1",
+    permission: str = NO_PERMISSION_REQUIRED,
 ) -> None:
     """Serve Swagger UI at `route` url path.
 
@@ -128,6 +130,7 @@ def add_explorer_view(
     :param route_name: Route name that's being added
     :param template: Dotted path to the html template that renders Swagger UI response
     :param ui_version: Swagger UI version string
+    :param permission: Permission for the explorer view
     """
 
     def register() -> None:
@@ -150,7 +153,11 @@ def add_explorer_view(
             return Response(html)
 
         config.add_route(route_name, route)
-        config.add_view(route_name=route_name, view=explorer_view)
+        config.add_view(
+            route_name=route_name,
+            permission=permission,
+            view=explorer_view
+        )
 
     config.action(("pyramid_openapi3_add_explorer",), register, order=PHASE0_CONFIG)
 
@@ -167,12 +174,14 @@ def add_spec_view(
     filepath: str,
     route: str = "/openapi.yaml",
     route_name: str = "pyramid_openapi3.spec",
+    permission: str = NO_PERMISSION_REQUIRED,
 ) -> None:
     """Serve and register OpenApi 3.0 specification file.
 
     :param filepath: absolute/relative path to the specification file
     :param route: URL path where to serve specification file
     :param route_name: Route name under which specification file will be served
+    :param permission: Permission for the spec view
     """
 
     def register() -> None:
@@ -194,7 +203,11 @@ def add_spec_view(
             return FileResponse(filepath, request=request, content_type="text/yaml")
 
         config.add_route(route_name, route)
-        config.add_view(route_name=route_name, view=spec_view)
+        config.add_view(
+            route_name=route_name,
+            permission=permission,
+            view=spec_view
+        )
 
         custom_formatters = config.registry.settings.get("pyramid_openapi3_formatters")
 

--- a/pyramid_openapi3/tests/test_permissions.py
+++ b/pyramid_openapi3/tests/test_permissions.py
@@ -84,7 +84,7 @@ OPENAPI_YAML = """
     ),
 )
 def test_permission_for_specs(route, permission, status) -> None:
-    """Render nice ValidationError if query parameter is missing."""
+    """Allow (200) or deny (403) access to the spec/explorer view."""
     with tempfile.NamedTemporaryFile() as document:
         document.write(OPENAPI_YAML.encode())
         document.seek(0)

--- a/pyramid_openapi3/tests/test_permissions.py
+++ b/pyramid_openapi3/tests/test_permissions.py
@@ -1,0 +1,94 @@
+"""Test rendering with permissions."""
+
+from pyramid.authentication import SessionAuthenticationPolicy
+from pyramid.authorization import ACLAuthorizationPolicy
+from pyramid.config import Configurator
+from pyramid.router import Router
+from pyramid.security import Allow
+from pyramid.security import Authenticated
+from pyramid.security import NO_PERMISSION_REQUIRED
+from pyramid.session import UnencryptedCookieSessionFactoryConfig
+from webtest.app import TestApp
+import pytest
+import tempfile
+
+DEFAULT_ACL = [
+    (Allow, Authenticated, "view"),
+]
+
+
+class DummyDefaultContext(object):
+
+    __acl__ = DEFAULT_ACL
+
+
+def get_default_context(request):
+    return DummyDefaultContext()
+
+
+def app(spec: str, permission: str) -> Router:
+    """Prepare a Pyramid app."""
+    with Configurator() as config:
+        config.include("pyramid_openapi3")
+
+        # Setup security
+        config.set_default_permission("view")
+        config.set_session_factory(
+            UnencryptedCookieSessionFactoryConfig("itsaseekreet")
+        )
+        config.set_authentication_policy(SessionAuthenticationPolicy())
+        config.set_authorization_policy(ACLAuthorizationPolicy())
+        config.set_root_factory(get_default_context)
+
+        config.pyramid_openapi3_spec(
+            spec,
+            route="/api/v1/openapi.yaml",
+            route_name="api_spec",
+            permission=permission,
+        )
+        config.pyramid_openapi3_add_explorer(
+            route="/api/v1/",
+            route_name="api_explorer",
+            permission=permission,
+        )
+        config.add_route("foo", "/foo")
+        return config.make_wsgi_app()
+
+
+OPENAPI_YAML = """
+    openapi: "3.0.0"
+    info:
+      version: "1.0.0"
+      title: Foo
+    paths:
+      /foo:
+        post:
+          parameters:
+            - name: bar
+              in: query
+              schema:
+                type: integer
+          responses:
+            200:
+              description: Say hello
+"""
+
+
+@pytest.mark.parametrize(
+    "route,permission,status",
+    (
+        ("/api/v1/openapi.yaml", None, 403),
+        ("/api/v1/openapi.yaml", NO_PERMISSION_REQUIRED, 200),
+        ("/api/v1/", None, 403),
+        ("/api/v1/", NO_PERMISSION_REQUIRED, 200),
+    ),
+)
+def test_permission_for_specs(route, permission, status) -> None:
+    """Render nice ValidationError if query parameter is missing."""
+    with tempfile.NamedTemporaryFile() as document:
+        document.write(OPENAPI_YAML.encode())
+        document.seek(0)
+
+        testapp = TestApp(app(document.name, permission))
+
+        testapp.get(route, status=status)


### PR DESCRIPTION
In an environment, where the default permission is not `NO_PERMISSION_REQUIRED`, spec and explorer view are not visible to non authenticated users.

This PR introduces the ability to set the permission explicitly for spec and explorer view.