### PR TITLE
Allow registering multiple apis in a single pyramid app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * Support for endpoint validation of prefixed routes.
   [zupo]
 
+* Allow setting permission for explorer and spec view.
+  [sweh]
+
 
 0.10.1 (2020-10-26)
 ------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 * Allow setting permission for explorer and spec view.
   [sweh]
 
+* Allow multiple OpenApis in one pyramid application.
+  [sweh]
+
 
 0.10.1 (2020-10-26)
 ------------------

--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -91,9 +91,9 @@ def openapi_view(view: View, info: ViewDeriverInfo) -> View:
             )
             request.environ["pyramid_openapi3.validate_response"] = validate_response
             gsettings = settings = request.registry.settings["pyramid_openapi3"]
-            if 'routes' in gsettings:
+            if "routes" in gsettings:
                 settings = request.registry.settings[
-                    gsettings['routes'][request.matched_route.name]
+                    gsettings["routes"][request.matched_route.name]
                 ]
 
             # Needed to support relative `servers` entries in `openapi.yaml`,
@@ -129,7 +129,7 @@ def add_explorer_view(
     template: str = "static/index.html",
     ui_version: str = "3.17.1",
     permission: str = NO_PERMISSION_REQUIRED,
-    apiname: str = 'pyramid_openapi3',
+    apiname: str = "pyramid_openapi3",
 ) -> None:
     """Serve Swagger UI at `route` url path.
 
@@ -153,9 +153,7 @@ def add_explorer_view(
                 template = Template(f.read())
                 html = template.safe_substitute(
                     ui_version=ui_version,
-                    spec_url=request.route_url(
-                        settings[apiname]["spec_route_name"]
-                    ),
+                    spec_url=request.route_url(settings[apiname]["spec_route_name"]),
                 )
             return Response(html)
 
@@ -180,7 +178,7 @@ def add_spec_view(
     route: str = "/openapi.yaml",
     route_name: str = "pyramid_openapi3.spec",
     permission: str = NO_PERMISSION_REQUIRED,
-    apiname: str = 'pyramid_openapi3',
+    apiname: str = "pyramid_openapi3",
 ) -> None:
     """Serve and register OpenApi 3.0 specification file.
 
@@ -226,7 +224,7 @@ def add_spec_view(
         }
         APIS.append(apiname)
 
-    config.action((f'{apiname}_spec',), register, order=PHASE0_CONFIG)
+    config.action((f"{apiname}_spec",), register, order=PHASE0_CONFIG)
 
 
 def add_spec_view_directory(
@@ -328,9 +326,7 @@ def check_all_routes(event: ApplicationCreated):
             )
             return
 
-        if not settings.get(
-            "pyramid_openapi3.enable_endpoint_validation", True
-        ):
+        if not settings.get("pyramid_openapi3.enable_endpoint_validation", True):
             logger.info("Endpoint validation against specification is disabled")
             return
 
@@ -350,10 +346,12 @@ def check_all_routes(event: ApplicationCreated):
 
         paths = list(openapi_settings["spec"].paths.keys())
         routes = [
-            remove_prefixes(route.path) for name, route in app.routes_mapper.routes.items()
+            remove_prefixes(route.path)
+            for name, route in app.routes_mapper.routes.items()
         ]
         route_names = {
-            remove_prefixes(route.path): name for name, route in app.routes_mapper.routes.items()
+            remove_prefixes(route.path): name
+            for name, route in app.routes_mapper.routes.items()
         }
 
         missing = [r for r in paths if r not in routes]
@@ -361,6 +359,6 @@ def check_all_routes(event: ApplicationCreated):
             raise MissingEndpointsError(missing)
 
         settings.setdefault("pyramid_openapi3", {})
-        settings['pyramid_openapi3'].setdefault('routes', {})
+        settings["pyramid_openapi3"].setdefault("routes", {})
         for path in paths:
             settings["pyramid_openapi3"]["routes"][route_names[path]] = name

--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -164,7 +164,7 @@ def add_explorer_view(
             route_name=route_name, permission=permission, view=explorer_view
         )
 
-    config.action((f"{apiname}_explorer",), register, order=PHASE0_CONFIG)
+    config.action((f"{apiname}_add_explorer",), register, order=PHASE0_CONFIG)
 
 
 def add_formatter(config: Configurator, name: str, func: t.Callable) -> None:

--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -34,6 +34,8 @@ import typing as t
 
 logger = logging.getLogger(__name__)
 
+APIS = []
+
 
 def includeme(config: Configurator) -> None:
     """Pyramid knob."""
@@ -88,7 +90,11 @@ def openapi_view(view: View, info: ViewDeriverInfo) -> View:
                 )
             )
             request.environ["pyramid_openapi3.validate_response"] = validate_response
-            settings = request.registry.settings["pyramid_openapi3"]
+            gsettings = settings = request.registry.settings["pyramid_openapi3"]
+            if 'routes' in gsettings:
+                settings = request.registry.settings[
+                    gsettings['routes'][request.matched_route.name]
+                ]
 
             # Needed to support relative `servers` entries in `openapi.yaml`,
             # see https://github.com/p1c2u/openapi-core/issues/218.
@@ -123,6 +129,7 @@ def add_explorer_view(
     template: str = "static/index.html",
     ui_version: str = "3.17.1",
     permission: str = NO_PERMISSION_REQUIRED,
+    apiname: str = 'pyramid_openapi3',
 ) -> None:
     """Serve Swagger UI at `route` url path.
 
@@ -138,7 +145,7 @@ def add_explorer_view(
 
         def explorer_view(request: Request) -> Response:
             settings = config.registry.settings
-            if settings.get("pyramid_openapi3") is None:
+            if settings.get(apiname) is None:
                 raise ConfigurationError(
                     "You need to call config.pyramid_openapi3_spec for explorer to work."
                 )
@@ -147,7 +154,7 @@ def add_explorer_view(
                 html = template.safe_substitute(
                     ui_version=ui_version,
                     spec_url=request.route_url(
-                        settings["pyramid_openapi3"]["spec_route_name"]
+                        settings[apiname]["spec_route_name"]
                     ),
                 )
             return Response(html)
@@ -159,7 +166,7 @@ def add_explorer_view(
             view=explorer_view
         )
 
-    config.action(("pyramid_openapi3_add_explorer",), register, order=PHASE0_CONFIG)
+    config.action((f"{apiname}_explorer",), register, order=PHASE0_CONFIG)
 
 
 def add_formatter(config: Configurator, name: str, func: t.Callable) -> None:
@@ -175,6 +182,7 @@ def add_spec_view(
     route: str = "/openapi.yaml",
     route_name: str = "pyramid_openapi3.spec",
     permission: str = NO_PERMISSION_REQUIRED,
+    apiname: str = 'pyramid_openapi3',
 ) -> None:
     """Serve and register OpenApi 3.0 specification file.
 
@@ -185,7 +193,7 @@ def add_spec_view(
     """
 
     def register() -> None:
-        settings = config.registry.settings.get("pyramid_openapi3")
+        settings = config.registry.settings.get(apiname)
         if settings and settings.get("spec") is not None:
             raise ConfigurationError(
                 "Spec has already been configured. You may only call "
@@ -211,7 +219,7 @@ def add_spec_view(
 
         custom_formatters = config.registry.settings.get("pyramid_openapi3_formatters")
 
-        config.registry.settings["pyramid_openapi3"] = {
+        config.registry.settings[apiname] = {
             "filepath": filepath,
             "spec_route_name": route_name,
             "spec": spec,
@@ -222,8 +230,9 @@ def add_spec_view(
                 spec, custom_formatters=custom_formatters
             ),
         }
+        APIS.append(apiname)
 
-    config.action(("pyramid_openapi3_spec",), register, order=PHASE0_CONFIG)
+    config.action((f'{apiname}_spec',), register, order=PHASE0_CONFIG)
 
 
 def add_spec_view_directory(
@@ -314,40 +323,50 @@ def check_all_routes(event: ApplicationCreated):
     """
 
     app = event.app
-    openapi_settings = app.registry.settings.get("pyramid_openapi3")
-    if not openapi_settings:
-        # pyramid_openapi3 not configured?
-        logger.warning(
-            "pyramid_openapi3 settings not found. "
-            "Did you forget to call config.pyramid_openapi3_spec?"
-        )
-        return
+    settings = app.registry.settings
+    for name in APIS:
+        openapi_settings = settings.get(name)
+        if not openapi_settings:
+            # pyramid_openapi3 not configured?
+            logger.warning(
+                "pyramid_openapi3 settings not found. "
+                "Did you forget to call config.pyramid_openapi3_spec?"
+            )
+            return
 
-    if not app.registry.settings.get(
-        "pyramid_openapi3.enable_endpoint_validation", True
-    ):
-        logger.info("Endpoint validation against specification is disabled")
-        return
+        if not settings.get(
+            "pyramid_openapi3.enable_endpoint_validation", True
+        ):
+            logger.info("Endpoint validation against specification is disabled")
+            return
 
-    # Sometimes api routes are prefixed with `/api/v1` and similar, using
-    # https://swagger.io/docs/specification/api-host-and-base-path/
-    prefixes = []
-    for server in openapi_settings["spec"].servers:
-        path = urlparse(server.url).path
-        if path != "/":
-            prefixes.append(path)
+        # Sometimes api routes are prefixed with `/api/v1` and similar, using
+        # https://swagger.io/docs/specification/api-host-and-base-path/
+        prefixes = []
+        for server in openapi_settings["spec"].servers:
+            path = urlparse(server.url).path
+            if path != "/":
+                prefixes.append(path)
 
-    def remove_prefixes(path):
-        path = f"/{path}" if not path.startswith("/") else path
-        for prefix in prefixes:
-            path = path.replace(prefix, "")
-        return path
+        def remove_prefixes(path):
+            path = f"/{path}" if not path.startswith("/") else path
+            for prefix in prefixes:
+                path = path.replace(prefix, "")
+            return path
 
-    paths = list(openapi_settings["spec"].paths.keys())
-    routes = [
-        remove_prefixes(route.path) for name, route in app.routes_mapper.routes.items()
-    ]
+        paths = list(openapi_settings["spec"].paths.keys())
+        routes = [
+            remove_prefixes(route.path) for name, route in app.routes_mapper.routes.items()
+        ]
+        route_names = {
+            remove_prefixes(route.path): name for name, route in app.routes_mapper.routes.items()
+        }
 
-    missing = [r for r in paths if r not in routes]
-    if missing:
-        raise MissingEndpointsError(missing)
+        missing = [r for r in paths if r not in routes]
+        if missing:
+            raise MissingEndpointsError(missing)
+
+        settings.setdefault("pyramid_openapi3", {})
+        settings['pyramid_openapi3'].setdefault('routes', {})
+        for path in paths:
+            settings["pyramid_openapi3"]["routes"][route_names[path]] = name

--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -22,6 +22,7 @@ from pyramid.path import AssetResolver
 from pyramid.request import Request
 from pyramid.response import FileResponse
 from pyramid.response import Response
+from pyramid.security import NO_PERMISSION_REQUIRED
 from pyramid.settings import asbool
 from pyramid.tweens import EXCVIEW
 from string import Template
@@ -121,6 +122,7 @@ def add_explorer_view(
     route_name: str = "pyramid_openapi3.explorer",
     template: str = "static/index.html",
     ui_version: str = "3.17.1",
+    permission: str = NO_PERMISSION_REQUIRED,
 ) -> None:
     """Serve Swagger UI at `route` url path.
 
@@ -128,6 +130,7 @@ def add_explorer_view(
     :param route_name: Route name that's being added
     :param template: Dotted path to the html template that renders Swagger UI response
     :param ui_version: Swagger UI version string
+    :param permission: Permission for the explorer view
     """
 
     def register() -> None:
@@ -150,7 +153,11 @@ def add_explorer_view(
             return Response(html)
 
         config.add_route(route_name, route)
-        config.add_view(route_name=route_name, view=explorer_view)
+        config.add_view(
+            route_name=route_name,
+            permission=permission,
+            view=explorer_view
+        )
 
     config.action(("pyramid_openapi3_add_explorer",), register, order=PHASE0_CONFIG)
 
@@ -167,12 +174,14 @@ def add_spec_view(
     filepath: str,
     route: str = "/openapi.yaml",
     route_name: str = "pyramid_openapi3.spec",
+    permission: str = NO_PERMISSION_REQUIRED,
 ) -> None:
     """Serve and register OpenApi 3.0 specification file.
 
     :param filepath: absolute/relative path to the specification file
     :param route: URL path where to serve specification file
     :param route_name: Route name under which specification file will be served
+    :param permission: Permission for the spec view
     """
 
     def register() -> None:
@@ -194,7 +203,11 @@ def add_spec_view(
             return FileResponse(filepath, request=request, content_type="text/yaml")
 
         config.add_route(route_name, route)
-        config.add_view(route_name=route_name, view=spec_view)
+        config.add_view(
+            route_name=route_name,
+            permission=permission,
+            view=spec_view
+        )
 
         custom_formatters = config.registry.settings.get("pyramid_openapi3_formatters")
 

--- a/pyramid_openapi3/tests/test_views.py
+++ b/pyramid_openapi3/tests/test_views.py
@@ -13,6 +13,7 @@ from pyramid.router import Router
 from pyramid.testing import DummyRequest
 from pyramid.testing import testConfig
 from pyramid_openapi3.exceptions import RequestValidationError
+from pyramid_openapi3 import check_all_routes
 
 import os
 import pytest
@@ -37,6 +38,19 @@ MINIMAL_DOCUMENT = b"""
           responses:
             200:
               description: A foo
+"""
+
+ALTERNATE_DOCUMENT = b"""
+    openapi: "3.0.0"
+    info:
+      version: "1.0.0"
+      title: Bar API
+    paths:
+      /bar:
+        get:
+          responses:
+            200:
+              description: A bar
 """
 
 SPLIT_DOCUMENT = b"""
@@ -263,6 +277,60 @@ def test_add_explorer_view() -> None:
         assert b"<title>Swagger UI</title>" in response.body
 
 
+def test_add_multiple_explorer_views() -> None:
+    """Test registration of multiple viewa serving different Swagger UI."""
+    with testConfig() as config:
+        config.include("pyramid_openapi3")
+
+        with tempfile.NamedTemporaryFile() as document:
+            document.write(MINIMAL_DOCUMENT)
+            document.seek(0)
+
+            config.pyramid_openapi3_spec(
+                document.name, route="/foo.yaml", route_name="foo_api_spec",
+                apiname='foo_api'
+            )
+            config.pyramid_openapi3_add_explorer(
+                route=f'/foo_api/v1/',
+                route_name=f'foo_api_explorer',
+                apiname='foo_api',
+            )
+
+        with tempfile.NamedTemporaryFile() as document:
+            document.write(ALTERNATE_DOCUMENT)
+            document.seek(0)
+
+            config.pyramid_openapi3_spec(
+                document.name, route="/bar.yaml", route_name="bar_api_spec",
+                apiname='bar_api'
+            )
+            config.pyramid_openapi3_add_explorer(
+                route=f'/bar_api/v1/',
+                route_name=f'bar_api_explorer',
+                apiname='bar_api',
+            )
+
+        request = config.registry.queryUtility(
+            IRouteRequest, name="foo_api_explorer"
+        )
+        view = config.registry.adapters.registered(
+            (IViewClassifier, request, Interface), IView, name=""
+        )
+        response = view(request=DummyRequest(config=config), context=None)
+        assert b"<title>Swagger UI</title>" in response.body
+        assert b'http://example.com/foo.yaml' in response.body
+
+        request = config.registry.queryUtility(
+            IRouteRequest, name="bar_api_explorer"
+        )
+        view = config.registry.adapters.registered(
+            (IViewClassifier, request, Interface), IView, name=""
+        )
+        response = view(request=DummyRequest(config=config), context=None)
+        assert b"<title>Swagger UI</title>" in response.body
+        assert b'http://example.com/bar.yaml' in response.body
+
+
 def test_explorer_view_missing_spec() -> None:
     """Test graceful failure if explorer view is not registered."""
     with testConfig() as config:
@@ -311,6 +379,67 @@ def test_openapi_view() -> None:
         )
         request = DummyRequest(config=config, content_type="text/html")
         request.matched_route = DummyRoute(name="foo", pattern="/foo")
+        context = None
+        response = view(context, request)
+
+        assert response.json == "bar"
+
+
+def test_multiple_openapi_views() -> None:
+    """Test registration multiple openapi views."""
+    with testConfig() as config:
+        config.include("pyramid_openapi3")
+
+        with tempfile.NamedTemporaryFile() as document:
+            document.write(MINIMAL_DOCUMENT)
+            document.seek(0)
+
+            config.pyramid_openapi3_spec(
+                document.name, route="/foo.yaml", route_name="foo_api_spec",
+                apiname='foo'
+            )
+
+        with tempfile.NamedTemporaryFile() as document:
+            document.write(ALTERNATE_DOCUMENT)
+            document.seek(0)
+
+            config.pyramid_openapi3_spec(
+                document.name, route="/bar.yaml", route_name="bar_api_spec",
+                apiname='bar'
+            )
+
+        config.add_route("foo", "/foo")
+        view_func = lambda *arg: "foo"  # noqa: E731
+        config.add_view(openapi=True, renderer="json", view=view_func, route_name="foo")
+
+        config.add_route("bar", "/bar")
+        view_func = lambda *arg: "bar"  # noqa: E731
+        config.add_view(openapi=True, renderer="json", view=view_func, route_name="bar")
+
+        # Simulate, that `check_all_routes` was called
+        settings = config.registry.settings
+        settings.setdefault("pyramid_openapi3", {})
+        settings['pyramid_openapi3'].setdefault('routes', {})
+        settings["pyramid_openapi3"]["routes"]['foo'] = 'foo'
+        settings["pyramid_openapi3"]["routes"]['bar'] = 'bar'
+
+        request_interface = config.registry.queryUtility(IRouteRequest, name="foo")
+        view = config.registry.adapters.registered(
+            (IViewClassifier, request_interface, Interface), IView, name=""
+        )
+        request = DummyRequest(config=config, content_type="text/html")
+        request.matched_route = DummyRoute(name="foo", pattern="/foo")
+        context = None
+        response = view(context, request)
+
+        assert response.json == "foo"
+
+        request_interface = config.registry.queryUtility(IRouteRequest, name="bar")
+        view = config.registry.adapters.registered(
+            (IViewClassifier, request_interface, Interface), IView, name=""
+        )
+        request = DummyRequest(config=config, content_type="text/html")
+        request.matched_route = DummyRoute(name="bar", pattern="/bar")
         context = None
         response = view(context, request)
 

--- a/pyramid_openapi3/tests/test_views.py
+++ b/pyramid_openapi3/tests/test_views.py
@@ -13,7 +13,6 @@ from pyramid.router import Router
 from pyramid.testing import DummyRequest
 from pyramid.testing import testConfig
 from pyramid_openapi3.exceptions import RequestValidationError
-from pyramid_openapi3 import check_all_routes
 
 import os
 import pytest
@@ -287,13 +286,15 @@ def test_add_multiple_explorer_views() -> None:
             document.seek(0)
 
             config.pyramid_openapi3_spec(
-                document.name, route="/foo.yaml", route_name="foo_api_spec",
-                apiname='foo_api'
+                document.name,
+                route="/foo.yaml",
+                route_name="foo_api_spec",
+                apiname="foo_api",
             )
             config.pyramid_openapi3_add_explorer(
-                route=f'/foo_api/v1/',
-                route_name=f'foo_api_explorer',
-                apiname='foo_api',
+                route="/foo_api/v1/",
+                route_name="foo_api_explorer",
+                apiname="foo_api",
             )
 
         with tempfile.NamedTemporaryFile() as document:
@@ -301,34 +302,32 @@ def test_add_multiple_explorer_views() -> None:
             document.seek(0)
 
             config.pyramid_openapi3_spec(
-                document.name, route="/bar.yaml", route_name="bar_api_spec",
-                apiname='bar_api'
+                document.name,
+                route="/bar.yaml",
+                route_name="bar_api_spec",
+                apiname="bar_api",
             )
             config.pyramid_openapi3_add_explorer(
-                route=f'/bar_api/v1/',
-                route_name=f'bar_api_explorer',
-                apiname='bar_api',
+                route="/bar_api/v1/",
+                route_name="bar_api_explorer",
+                apiname="bar_api",
             )
 
-        request = config.registry.queryUtility(
-            IRouteRequest, name="foo_api_explorer"
-        )
+        request = config.registry.queryUtility(IRouteRequest, name="foo_api_explorer")
         view = config.registry.adapters.registered(
             (IViewClassifier, request, Interface), IView, name=""
         )
         response = view(request=DummyRequest(config=config), context=None)
         assert b"<title>Swagger UI</title>" in response.body
-        assert b'http://example.com/foo.yaml' in response.body
+        assert b"http://example.com/foo.yaml" in response.body
 
-        request = config.registry.queryUtility(
-            IRouteRequest, name="bar_api_explorer"
-        )
+        request = config.registry.queryUtility(IRouteRequest, name="bar_api_explorer")
         view = config.registry.adapters.registered(
             (IViewClassifier, request, Interface), IView, name=""
         )
         response = view(request=DummyRequest(config=config), context=None)
         assert b"<title>Swagger UI</title>" in response.body
-        assert b'http://example.com/bar.yaml' in response.body
+        assert b"http://example.com/bar.yaml" in response.body
 
 
 def test_explorer_view_missing_spec() -> None:
@@ -395,8 +394,10 @@ def test_multiple_openapi_views() -> None:
             document.seek(0)
 
             config.pyramid_openapi3_spec(
-                document.name, route="/foo.yaml", route_name="foo_api_spec",
-                apiname='foo'
+                document.name,
+                route="/foo.yaml",
+                route_name="foo_api_spec",
+                apiname="foo",
             )
 
         with tempfile.NamedTemporaryFile() as document:
@@ -404,8 +405,10 @@ def test_multiple_openapi_views() -> None:
             document.seek(0)
 
             config.pyramid_openapi3_spec(
-                document.name, route="/bar.yaml", route_name="bar_api_spec",
-                apiname='bar'
+                document.name,
+                route="/bar.yaml",
+                route_name="bar_api_spec",
+                apiname="bar",
             )
 
         config.add_route("foo", "/foo")
@@ -419,9 +422,9 @@ def test_multiple_openapi_views() -> None:
         # Simulate, that `check_all_routes` was called
         settings = config.registry.settings
         settings.setdefault("pyramid_openapi3", {})
-        settings['pyramid_openapi3'].setdefault('routes', {})
-        settings["pyramid_openapi3"]["routes"]['foo'] = 'foo'
-        settings["pyramid_openapi3"]["routes"]['bar'] = 'bar'
+        settings["pyramid_openapi3"].setdefault("routes", {})
+        settings["pyramid_openapi3"]["routes"]["foo"] = "foo"
+        settings["pyramid_openapi3"]["routes"]["bar"] = "bar"
 
         request_interface = config.registry.queryUtility(IRouteRequest, name="foo")
         view = config.registry.adapters.registered(

--- a/pyramid_openapi3/tween.py
+++ b/pyramid_openapi3/tween.py
@@ -32,10 +32,10 @@ def response_tween_factory(handler, registry) -> t.Callable[[Request], Response]
             # validate response
             openapi_request = PyramidOpenAPIRequestFactory.create(request)
             openapi_response = PyramidOpenAPIResponseFactory.create(response)
-            settings_key = 'pyramid_openapi3'
+            settings_key = "pyramid_openapi3"
             gsettings = settings = request.registry.settings[settings_key]
-            if 'routes' in gsettings:
-                settings_key = gsettings['routes'][request.matched_route.name]
+            if "routes" in gsettings:
+                settings_key = gsettings["routes"][request.matched_route.name]
                 settings = request.registry.settings[settings_key]
             result = settings["response_validator"].validate(
                 request=openapi_request, response=openapi_response

--- a/pyramid_openapi3/tween.py
+++ b/pyramid_openapi3/tween.py
@@ -32,7 +32,11 @@ def response_tween_factory(handler, registry) -> t.Callable[[Request], Response]
             # validate response
             openapi_request = PyramidOpenAPIRequestFactory.create(request)
             openapi_response = PyramidOpenAPIResponseFactory.create(response)
-            settings = request.registry.settings["pyramid_openapi3"]
+            settings_key = 'pyramid_openapi3'
+            gsettings = settings = request.registry.settings[settings_key]
+            if 'routes' in gsettings:
+                settings_key = gsettings['routes'][request.matched_route.name]
+                settings = request.registry.settings[settings_key]
             result = settings["response_validator"].validate(
                 request=openapi_request, response=openapi_response
             )
@@ -50,7 +54,7 @@ def response_tween_factory(handler, registry) -> t.Callable[[Request], Response]
                             )
                         ),
                         None,
-                        registry.settings["pyramid_openapi3"]["filepath"],
+                        registry.settings[settings_key]["filepath"],
                         0,
                     )
                 raise ResponseValidationError(response=response, errors=result.errors)


### PR DESCRIPTION
Currently there is only one api (with multiple endpoints) per application allowed (either via a single spec file or multiple splitted spec files).

I need to register different apis in one pyramid application, e.g. /fooapi and /barapi.

This PR introduces a new keyword argument `apiname` to `add_spec_view()` and `add_explorer_view()`, which "groups" spec and explorer together:

```
…
config.include('pyramid_openapi3')

# fooapi
config.pyramid_openapi3_spec(
    'fooapi.json',
    route='/fooapi/v1/openapi.yaml',
    route_name='fooapi_spec',
    apiname='fooapi',
)
config.pyramid_openapi3_add_explorer(
    route='/fooapi/v1/',
    route_name='fooapi_explorer',
    apiname='fooapi',
)

# barapi
config.pyramid_openapi3_spec(
    'barapi.json',
    route='/barapi/v1/openapi.yaml',
    route_name='barapi_spec',
    apiname='barapi',
)
config.pyramid_openapi3_add_explorer(
    route='/barapi/v1/',
    route_name='barapi_explorer',
    apiname='barapi',
)
```

If you think this is a welcome addition, I would be happy if we could bring this into the next release.