### PR TITLE
Bugfix for same endpoint name in multiple OpenApis.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+0.11.1 (unreleased)
+-------------------
+
+* Bugfix for same endpoint name in multiple OpenApis.
+  [sweh]
 
 0.11 (2021-02-15)
 -----------------

--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -30,6 +30,7 @@ from urllib.parse import urlparse
 
 import hupper
 import logging
+import os.path
 import typing as t
 
 logger = logging.getLogger(__name__)
@@ -350,8 +351,7 @@ def check_all_routes(event: ApplicationCreated):
             for name, route in app.routes_mapper.routes.items()
         ]
         route_names = {
-            remove_prefixes(route.path): name
-            for name, route in app.routes_mapper.routes.items()
+            route.path: name for name, route in app.routes_mapper.routes.items()
         }
 
         missing = [r for r in paths if r not in routes]
@@ -360,5 +360,8 @@ def check_all_routes(event: ApplicationCreated):
 
         settings.setdefault("pyramid_openapi3", {})
         settings["pyramid_openapi3"].setdefault("routes", {})
+        base_path = path
         for path in paths:
-            settings["pyramid_openapi3"]["routes"][route_names[path]] = name
+            path = os.path.join(base_path, path)
+            if path in route_names:
+                settings["pyramid_openapi3"]["routes"][route_names[path]] = name


### PR DESCRIPTION
If you have multiple OpenApis and an endpoint has the same path name in at those specs, only one of those endpoints would be accessible for API calls.

Example:

spec1 introduces `/add` and others under server `http://example.com/api/myfirstapi/add` and spec2 introduces `/add` and others under server `http://example.com/api/mysecondapi/add`. The calls to `mysecondapi/add` currently result in an error.

This also opens the possibility to serve the same api under different versions, by keeping the endpoints stable, e.g.:

* `/api/myapi/v1/add_stuff`
* `/api/myapi/v2/add_stuff`