### PR TITLE
Fix `KeyError` when having multiple routes for a single path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,6 @@ typecov/
 
 # support for fast reloading direnv
 .direnv
+
+# Editors
+.vscode

--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -364,8 +364,7 @@ def check_all_routes(event: ApplicationCreated):
 
 
 def _get_server_prefixes(spec: Spec) -> t.List[str]:
-    """
-    Build a set of possible route prefixes from the api spec.
+    """Build a set of possible route prefixes from the api spec.
 
     Api routes may optionally be prefixed using servers (e.g: `/api/v1`).
     See: https://swagger.io/docs/specification/api-host-and-base-path/

--- a/pyramid_openapi3/tests/test_views.py
+++ b/pyramid_openapi3/tests/test_views.py
@@ -344,7 +344,10 @@ def test_explorer_view_missing_spec() -> None:
         )
         with pytest.raises(
             ConfigurationError,
-            match="You need to call config.pyramid_openapi3_spec for explorer to work.",
+            match=(
+                "You need to call config.pyramid_openapi3_spec for the "
+                "explorer to work."
+            ),
         ):
             view(request=DummyRequest(config=config), context=None)
 


### PR DESCRIPTION
## Initial Issue

- Pyramid allows you to have multiple routes applied to the same path (using `predicates` or `request_method`).
    - e.g: 
    ```python
    config.add_route("todos", "/")
    ```
    vs
    ```python
    config.add_route("get_todos", "/", request_method="GET")
    config.add_route("create_todo", "/", request_method="POST")
    ```
  - Currently this will create the app without error, but cause a `KeyError` when attempting to actually call the endpoint
  - This is because the `routes` object is currently built up using a dictionary of `path` -> `route_name` (so the second route would overwrite the first).

## Changes

- Change the building of the `routes` settings object to loop through each route (by route_name) to fix the aforementioned issue (resulting `routes` object remains the same)
- Add some extra checks in the `openapi_view` deriver so that openapi can produce the notfound, rather than getting a `KeyError`, should the given route_name not be present in the `routes` object
    - Basically just check that the `route_name` exists inside the `routes` object before trying to use index it.
- Minor improvement to `remove_prefixes` in that it will actually check if it is a prefix (instead of a naïve string replace anywhere in the string)

## Question

- The building of the `routes` settings object (for multi-apis) is done at the end of the `check_all_routes` function. This means that if you disable endpoint validation (`pyramid_openapi3.enable_endpoint_validation = False`) you will not have this settings object.
    - I think we should either: Move this to its own function (also subscribing to the application created), or move it above the check against the `pyramid_openapi3.enable_endpoint_validation` setting.
    - This could be done in a separate branch / PR