### PR TITLE
add register_routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,33 @@ config.registry.settings["pyramid_openapi3.enable_response_validation"] = False
 > **Warning:**
 Disabling request validation will result in `request.openapi_validated` no longer being available to use.
 
+### Register Pyramid's Routes
+
+You can register routes in your pyramid application.
+First, write the `x-pyramid-route-name` extension in the PathItem of the OpenAPI schema.
+
+```yaml
+paths:
+  /foo:
+    x-pyramid-route-name: foo_route
+    get:
+      responses:
+        200:
+          description: GET foo
+```
+
+Then put the config directive `pyramid_openapi3_register_routes` in the app_factory of your application.
+
+```python
+config.pyramid_openapi3_register_routes()
+```
+
+This means is equals to
+
+```python
+config.add_route("foo_route", pattern="/foo")
+```
+
 ## Demo / Examples
 
 There are three examples provided with this package:

--- a/pyramid_openapi3/tests/test_routes.py
+++ b/pyramid_openapi3/tests/test_routes.py
@@ -1,0 +1,70 @@
+"""Tests routes."""
+
+from pyramid.request import Request
+from pyramid.testing import testConfig
+
+import tempfile
+
+
+def dummy_factory(request: Request) -> str:
+    """Root factory for testing."""
+    return "_DUMMY_"  # pragma: no cover
+
+
+def test_register_routes_simple() -> None:
+    """Test registration routes without root_factory."""
+    with testConfig() as config:
+        config.include("pyramid_openapi3")
+        with tempfile.NamedTemporaryFile() as tempdoc:
+            tempdoc.write(
+                b"""\
+openapi: "3.0.0"
+info:
+  version: "1.0.0"
+  title: Foo API
+paths:
+  /foo:
+    x-pyramid-route-name: foo
+    get:
+      responses:
+        200:
+          description: A foo
+  /bar:
+    get:
+      responses:
+        200:
+          description: A bar
+"""
+            )
+            tempdoc.seek(0)
+            config.pyramid_openapi3_spec(tempdoc.name)
+            config.pyramid_openapi3_register_routes()
+            config.add_route("bar", "/bar")
+            config.make_wsgi_app()
+
+
+def test_register_routes_with_factory() -> None:
+    """Test registration routes with root_factory."""
+    with testConfig() as config:
+        config.include("pyramid_openapi3")
+        with tempfile.NamedTemporaryFile() as tempdoc:
+            tempdoc.write(
+                b"""\
+openapi: "3.0.0"
+info:
+  version: "1.0.0"
+  title: Foo API
+paths:
+  /foo:
+    x-pyramid-route-name: foo
+    x-pyramid-root-factory: pyramid_openapi3.tests.test_routes.dummy_factory
+    get:
+      responses:
+        200:
+          description: A foo
+"""
+            )
+            tempdoc.seek(0)
+            config.pyramid_openapi3_spec(tempdoc.name)
+            config.pyramid_openapi3_register_routes()
+            config.make_wsgi_app()


### PR DESCRIPTION
Add config directive `pyramid_openapi3_register_routes` which registers routes from Open API Schema's `x-pyramid-route-name` extensions.

Refs #46