### PR TITLE
Remove old relative openapi server url workaround.

### DIFF
--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -100,11 +100,6 @@ def openapi_view(view: View, info: ViewDeriverInfo) -> View:
                     route_settings[request.matched_route.name]
                 ]
 
-            # Needed to support relative `servers` entries in `openapi.yaml`,
-            # see https://github.com/p1c2u/openapi-core/issues/218.
-            settings["request_validator"].base_url = request.application_url
-            settings["response_validator"].base_url = request.application_url
-
             if validate_request:
                 request.environ["pyramid_openapi3.validate_request"] = True
                 openapi_request = PyramidOpenAPIRequestFactory.create(request)

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,6 @@ setup(
     keywords="pyramid openapi3 openapi rest restful",
     packages=find_packages(exclude=["tests"]),
     include_package_data=True,
-    install_requires=["openapi-core>=0.13.1", "openapi-spec-validator", "pyramid"],
+    install_requires=["openapi-core>=0.13.4", "openapi-spec-validator", "pyramid"],
     cmdclass={"verify": VerifyVersionCommand},
 )


### PR DESCRIPTION
Modifying the global `settings` causes a race condition with concurrent requests that have different `request.application_url`.

The fix is to simply remove the old workaround and use a newer version of openapi-core. Openapi-core has support for relative server URLs since 0.13.4.
