### PR TITLE
fixes #136

### DIFF
--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -360,14 +360,7 @@ def check_all_routes(event: ApplicationCreated):
         return
 
     for name in apinames:  # pragma: no branch
-        openapi_settings = settings.get(name)
-        if not openapi_settings:
-            # pyramid_openapi3 not configured?
-            logger.warning(
-                "pyramid_openapi3 settings not found. "
-                "Did you forget to call config.pyramid_openapi3_spec?"
-            )
-            return
+        openapi_settings = settings[name]
 
         if not settings.get("pyramid_openapi3.enable_endpoint_validation", True):
             logger.info("Endpoint validation against specification is disabled")

--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -227,7 +227,9 @@ def add_spec_view(
                 spec, custom_formatters=custom_formatters
             ),
         }
-        config.registry.settings.setdefault("pyramid_openapi3_apis", []).append(apiname)
+        config.registry.settings.setdefault("pyramid_openapi3_apinames", []).append(
+            apiname
+        )
 
     config.action((f"{apiname}_spec",), register, order=PHASE0_CONFIG)
 
@@ -348,8 +350,8 @@ def check_all_routes(event: ApplicationCreated):
 
     app = event.app
     settings = app.registry.settings
-    apis = settings.get("pyramid_openapi3_apis")
-    if not apis:
+    apinames = settings.get("pyramid_openapi3_apinames")
+    if not apinames:
         # pyramid_openapi3 not configured?
         logger.warning(
             "pyramid_openapi3 settings not found. "
@@ -357,7 +359,7 @@ def check_all_routes(event: ApplicationCreated):
         )
         return
 
-    for name in apis:  # pragma: no branch
+    for name in apinames:  # pragma: no branch
         openapi_settings = settings.get(name)
         if not openapi_settings:
             # pyramid_openapi3 not configured?


### PR DESCRIPTION
the global variable `pyramid_openapi3.APIS` has wrong side effects on multiple instantiation environments such as testing.
this patch removes it and moves to registry.
