### PR TITLE
Add custom deserializers

### DIFF
--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -42,6 +42,7 @@ def includeme(config: Configurator) -> None:
     config.add_request_method(openapi_validated, name="openapi_validated", reify=True)
     config.add_view_deriver(openapi_view)
     config.add_directive("pyramid_openapi3_add_formatter", add_formatter)
+    config.add_directive("pyramid_openapi3_add_deserializer", add_deserializer)
     config.add_directive("pyramid_openapi3_add_explorer", add_explorer_view)
     config.add_directive("pyramid_openapi3_spec", add_spec_view)
     config.add_directive("pyramid_openapi3_spec_directory", add_spec_view_directory)
@@ -176,6 +177,11 @@ def add_formatter(config: Configurator, name: str, func: t.Callable) -> None:
     reg = config.registry.settings["pyramid_openapi3_formatters"]
     reg[name] = func
 
+def add_deserializer(config: Configurator, name: str, func: t.Callable) -> None:
+    """Add support for configuring deserializers."""
+    config.registry.settings.setdefault("pyramid_openapi3_deserializers", {})
+    reg = config.registry.settings["pyramid_openapi3_deserializers"]
+    reg[name] = func
 
 def add_spec_view(
     config: Configurator,
@@ -215,16 +221,21 @@ def add_spec_view(
         config.add_view(route_name=route_name, permission=permission, view=spec_view)
 
         custom_formatters = config.registry.settings.get("pyramid_openapi3_formatters")
+        custom_deserializers = config.registry.settings.get("pyramid_openapi3_deserializers")
 
         config.registry.settings[apiname] = {
             "filepath": filepath,
             "spec_route_name": route_name,
             "spec": spec,
             "request_validator": RequestValidator(
-                spec, custom_formatters=custom_formatters
+                spec, 
+                custom_formatters=custom_formatters,
+                custom_media_type_deserializers=custom_deserializers
             ),
             "response_validator": ResponseValidator(
-                spec, custom_formatters=custom_formatters
+                spec, 
+                custom_formatters=custom_formatters,
+                custom_media_type_deserializers=custom_deserializers
             ),
         }
         config.registry.settings.setdefault("pyramid_openapi3_apinames", []).append(
@@ -274,16 +285,21 @@ def add_spec_view_directory(
         config.add_route(route_name, f"{route}/{path.name}")
 
         custom_formatters = config.registry.settings.get("pyramid_openapi3_formatters")
+        custom_deserializers = config.registry.settings.get("pyramid_openapi3_deserializers")
 
         config.registry.settings[apiname] = {
             "filepath": filepath,
             "spec_route_name": route_name,
             "spec": spec,
             "request_validator": RequestValidator(
-                spec, custom_formatters=custom_formatters
+                spec,
+                custom_formatters=custom_formatters,
+                custom_media_type_deserializers=custom_deserializers
             ),
             "response_validator": ResponseValidator(
-                spec, custom_formatters=custom_formatters
+                spec, 
+                custom_formatters=custom_formatters,
+                custom_media_type_deserializers=custom_deserializers
             ),
         }
         config.registry.settings.setdefault("pyramid_openapi3_apinames", []).append(

--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -177,11 +177,13 @@ def add_formatter(config: Configurator, name: str, func: t.Callable) -> None:
     reg = config.registry.settings["pyramid_openapi3_formatters"]
     reg[name] = func
 
+
 def add_deserializer(config: Configurator, name: str, func: t.Callable) -> None:
     """Add support for configuring deserializers."""
     config.registry.settings.setdefault("pyramid_openapi3_deserializers", {})
     reg = config.registry.settings["pyramid_openapi3_deserializers"]
     reg[name] = func
+
 
 def add_spec_view(
     config: Configurator,

--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -230,12 +230,12 @@ def add_spec_view(
             "spec_route_name": route_name,
             "spec": spec,
             "request_validator": RequestValidator(
-                spec, 
+                spec,
                 custom_formatters=custom_formatters,
                 custom_media_type_deserializers=custom_deserializers
             ),
             "response_validator": ResponseValidator(
-                spec, 
+                spec,
                 custom_formatters=custom_formatters,
                 custom_media_type_deserializers=custom_deserializers
             ),
@@ -299,7 +299,7 @@ def add_spec_view_directory(
                 custom_media_type_deserializers=custom_deserializers
             ),
             "response_validator": ResponseValidator(
-                spec, 
+                spec,
                 custom_formatters=custom_formatters,
                 custom_media_type_deserializers=custom_deserializers
             ),

--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -223,7 +223,9 @@ def add_spec_view(
         config.add_view(route_name=route_name, permission=permission, view=spec_view)
 
         custom_formatters = config.registry.settings.get("pyramid_openapi3_formatters")
-        custom_deserializers = config.registry.settings.get("pyramid_openapi3_deserializers")
+        custom_deserializers = config.registry.settings.get(
+            "pyramid_openapi3_deserializers"
+        )
 
         config.registry.settings[apiname] = {
             "filepath": filepath,
@@ -287,7 +289,9 @@ def add_spec_view_directory(
         config.add_route(route_name, f"{route}/{path.name}")
 
         custom_formatters = config.registry.settings.get("pyramid_openapi3_formatters")
-        custom_deserializers = config.registry.settings.get("pyramid_openapi3_deserializers")
+        custom_deserializers = config.registry.settings.get(
+            "pyramid_openapi3_deserializers"
+        )
 
         config.registry.settings[apiname] = {
             "filepath": filepath,

--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -232,12 +232,12 @@ def add_spec_view(
             "request_validator": RequestValidator(
                 spec,
                 custom_formatters=custom_formatters,
-                custom_media_type_deserializers=custom_deserializers
+                custom_media_type_deserializers=custom_deserializers,
             ),
             "response_validator": ResponseValidator(
                 spec,
                 custom_formatters=custom_formatters,
-                custom_media_type_deserializers=custom_deserializers
+                custom_media_type_deserializers=custom_deserializers,
             ),
         }
         config.registry.settings.setdefault("pyramid_openapi3_apinames", []).append(
@@ -296,12 +296,12 @@ def add_spec_view_directory(
             "request_validator": RequestValidator(
                 spec,
                 custom_formatters=custom_formatters,
-                custom_media_type_deserializers=custom_deserializers
+                custom_media_type_deserializers=custom_deserializers,
             ),
             "response_validator": ResponseValidator(
                 spec,
                 custom_formatters=custom_formatters,
-                custom_media_type_deserializers=custom_deserializers
+                custom_media_type_deserializers=custom_deserializers,
             ),
         }
         config.registry.settings.setdefault("pyramid_openapi3_apinames", []).append(

--- a/pyramid_openapi3/tests/test_add_deserializer.py
+++ b/pyramid_openapi3/tests/test_add_deserializer.py
@@ -13,7 +13,7 @@ def test_add_deserializer() -> None:
         config.include("pyramid_openapi3")
         config.pyramid_openapi3_add_deserializer("deserializer", lambda x: x)
 
-        deserializer = request.registry.settings["pyramid_openapi3_deserializer"].get(
+        deserializer = request.registry.settings["pyramid_openapi3_deserializers"].get(
             "deserializer", None
         )
         assert deserializer("foo") == "foo"

--- a/pyramid_openapi3/tests/test_add_deserializer.py
+++ b/pyramid_openapi3/tests/test_add_deserializer.py
@@ -1,0 +1,19 @@
+"""Tests for registering custom deserializers."""
+
+from pyramid.testing import DummyRequest
+from pyramid.testing import testConfig
+
+
+def test_add_deserializer() -> None:
+    """Test registration of a custom deserializer."""
+
+    with testConfig() as config:
+        request = DummyRequest()
+
+        config.include("pyramid_openapi3")
+        config.pyramid_openapi3_add_deserializer("deserializer", lambda x: x)
+
+        deserializer = request.registry.settings["pyramid_openapi3_deserializer"].get(
+            "deserializer", None
+        )
+        assert deserializer("foo") == "foo"


### PR DESCRIPTION

Openapi-core supports custom deserializers which converts mimetypes other than json into objects that can then be validated.

This patch allows developers to call config.pyramid_openapi3_add_deserializer and add additional deserializers. It is modeled after customer_formatters