### PR TITLE
Disable external spec validation performed by Swagger UI

### DIFF
--- a/pyramid_openapi3/static/index.html
+++ b/pyramid_openapi3/static/index.html
@@ -81,6 +81,7 @@
             plugins: [
                 SwaggerUIBundle.plugins.DownloadUrl
             ],
+            validatorUrl: null,
             layout: "StandaloneLayout"
         })
         window.ui = ui


### PR DESCRIPTION
- Disable the external spec validation performed by Swagger UI (fixes #152)
    - See [here](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md#network) for details on the `validatorUrl` configuration option
    - We already do spec validation on the pyramid server, so don't need to do it again
    - Since this extra validation is external, if your spec file is not publicly accessible, it would report it as invalid