### PR TITLE
Add setting to enable/disable automatic creation of exception views

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,4 +202,4 @@ A couple of projects that use pyramid_openapi3 in production:
 - [WooCart API](https://app.woocart.com/api/v1) - User control panel for WooCart Managed WooCommerce service.
 - [Kafkai API](https://app.kafkai.com/api/v1) - User control panel for Kafkai text generation service.
 - [Open on-chain data API](https://tradingstrategy.ai/api/explorer/) - Decentralised exchange and blockchain trading data open API
-- [Pareto Security Team Dashboard API](https://dash.paretosecurity.app/api/v1) - Team Dashboard for Pareto Security macOS security app 
+- [Pareto Security Team Dashboard API](https://dash.paretosecurity.app/api/v1) - Team Dashboard for Pareto Security macOS security app

--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -55,13 +55,19 @@ def includeme(config: Configurator) -> None:
     ):
         config.registry.settings["pyramid_openapi3_extract_errors"] = extract_errors
 
-    config.add_exception_view(
-        view=openapi_validation_error, context=RequestValidationError, renderer="json"
-    )
-
-    config.add_exception_view(
-        view=openapi_validation_error, context=ResponseValidationError, renderer="json"
-    )
+    if asbool(
+        config.registry.settings.get("pyramid_openapi3.add_exception_views", True)
+    ):
+        config.add_exception_view(
+            view=openapi_validation_error,
+            context=RequestValidationError,
+            renderer="json",
+        )
+        config.add_exception_view(
+            view=openapi_validation_error,
+            context=ResponseValidationError,
+            renderer="json",
+        )
 
 
 def openapi_validated(request: Request) -> dict:

--- a/pyramid_openapi3/tests/test_add_exception_views.py
+++ b/pyramid_openapi3/tests/test_add_exception_views.py
@@ -1,0 +1,55 @@
+"""Tests for pyramid_openapi3.add_exception_views setting."""
+
+from pyramid.testing import testConfig
+from pyramid_openapi3 import openapi_validation_error
+from pyramid_openapi3.exceptions import RequestValidationError
+from pyramid_openapi3.exceptions import ResponseValidationError
+
+
+def test_add_exception_views__missing() -> None:
+    """Test exception views are created when pyramid_openapi3.add_exception_views setting is missing."""
+
+    with testConfig() as config:
+        config.include("pyramid_openapi3")
+
+        views = {
+            view["introspectable"]["context"]: view["introspectable"]["callable"]
+            for view in config.registry.introspector.get_category("views") or []
+        }
+
+        assert views[RequestValidationError] == openapi_validation_error
+        assert views[ResponseValidationError] == openapi_validation_error
+
+
+def test_add_exception_views__true() -> None:
+    """Test exception views are created when pyramid_openapi3.add_exception_views setting is True."""
+
+    with testConfig() as config:
+        config.registry.settings["pyramid_openapi3.add_exception_views"] = True
+
+        config.include("pyramid_openapi3")
+
+        views = {
+            view["introspectable"]["context"]: view["introspectable"]["callable"]
+            for view in config.registry.introspector.get_category("views") or []
+        }
+
+        assert views[RequestValidationError] == openapi_validation_error
+        assert views[ResponseValidationError] == openapi_validation_error
+
+
+def test_add_exception_views__false() -> None:
+    """Test exception views are not created when pyramid_openapi3.add_exception_views setting is False."""
+
+    with testConfig() as config:
+        config.registry.settings["pyramid_openapi3.add_exception_views"] = False
+
+        config.include("pyramid_openapi3")
+
+        views = {
+            view["introspectable"]["context"]: view["introspectable"]["callable"]
+            for view in config.registry.introspector.get_category("views") or []
+        }
+
+        assert RequestValidationError not in views
+        assert ResponseValidationError not in views


### PR DESCRIPTION
Unfortunately, the response body schema used by the automatically created exception views (`openapi_validation_error`) does not match the schema that is required for a new project I'm working on. I'd like to be able to just disable these views and add my own. Please let me know if there's already a way to do this!