### PR TITLE
Use the latest Swagger UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,4 +202,4 @@ A couple of projects that use pyramid_openapi3 in production:
 - [WooCart API](https://app.woocart.com/api/v1) - User control panel for WooCart Managed WooCommerce service.
 - [Kafkai API](https://app.kafkai.com/api/v1) - User control panel for Kafkai text generation service.
 - [Open on-chain data API](https://tradingstrategy.ai/api/explorer/) - Decentralised exchange and blockchain trading data open API
-- [Pareto Security Team Dashboard API](https://dash.paretosecurity.app/api/v1) - Team Dashboard for Pareto Security macOS security app 
+- [Pareto Security Team Dashboard API](https://dash.paretosecurity.app/api/v1) - Team Dashboard for Pareto Security macOS security app

--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -132,7 +132,7 @@ def add_explorer_view(
     route: str = "/docs/",
     route_name: str = "pyramid_openapi3.explorer",
     template: str = "static/index.html",
-    ui_version: str = "3.17.1",
+    ui_version: str = "4.10.3",
     permission: str = NO_PERMISSION_REQUIRED,
     apiname: str = "pyramid_openapi3",
 ) -> None:


### PR DESCRIPTION
Update to the latest Swagger UI https://github.com/swagger-api/swagger-ui/releases to get security and bug fixes.

The old 3.17.1 version and the latest 4.10.3 version support same OpenAPI spec versions (2.0, 3.0), so there shouldn't be any compatibility issues.