### PR TITLE
config.add_exception_view does not need renderers=json

### DIFF
--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -56,11 +56,11 @@ def includeme(config: Configurator) -> None:
         config.registry.settings["pyramid_openapi3_extract_errors"] = extract_errors
 
     config.add_exception_view(
-        view=openapi_validation_error, context=RequestValidationError, renderer="json"
+        view=openapi_validation_error, context=RequestValidationError
     )
 
     config.add_exception_view(
-        view=openapi_validation_error, context=ResponseValidationError, renderer="json"
+        view=openapi_validation_error, context=ResponseValidationError
     )
 
 


### PR DESCRIPTION
As pointed out by @atronah in #154, this is probably not needed.