### PR TITLE
request.openapi_validated does not break non-opeanpi views

### DIFF
--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -66,25 +66,20 @@ def includeme(config: Configurator) -> None:
 
 def openapi_validated(request: Request) -> dict:
     """Get validated parameters."""
-    # Validate request and attach all findings for view to introspect
-    validate_request = asbool(
-        request.registry.settings.get(
-            "pyramid_openapi3.enable_request_validation", True
+
+    # We need this here in case someone calls request.openapi_validated on
+    # a view marked with openapi=False
+    if not request.environ.get("pyramid_openapi3.enabled"):
+        raise AttributeError(
+            "Cannot do openapi request validation on a view marked with openapi=False"
         )
-    )
-    validate_response = asbool(
-        request.registry.settings.get(
-            "pyramid_openapi3.enable_response_validation", True
-        )
-    )
-    request.environ["pyramid_openapi3.validate_response"] = validate_response
+
     gsettings = settings = request.registry.settings["pyramid_openapi3"]
     route_settings = gsettings.get("routes")
     if route_settings and request.matched_route.name in route_settings:
         settings = request.registry.settings[route_settings[request.matched_route.name]]
 
-    if validate_request:  # pragma: no branch
-        request.environ["pyramid_openapi3.validate_request"] = True
+    if request.environ.get("pyramid_openapi3.validate_request"):
         openapi_request = PyramidOpenAPIRequestFactory.create(request)
         validated = settings["request_validator"].validate(openapi_request)
         return validated
@@ -109,12 +104,29 @@ def openapi_view(view: View, info: ViewDeriverInfo) -> View:
     if info.options.get("openapi"):
 
         def wrapper_view(context: Context, request: Request) -> Response:
-            validate_request = asbool(
+
+            # We need this to be able to raise AttributeError if view code
+            # accesses request.openapi_validated on a view that is marked
+            # with openapi=False
+            request.environ["pyramid_openapi3.enabled"] = True
+
+            # If view is marked with openapi=True (i.e. we are in this
+            # function) and registry settings are not set to disable
+            # validation, then do request/response validation
+            request.environ["pyramid_openapi3.validate_request"] = asbool(
                 request.registry.settings.get(
                     "pyramid_openapi3.enable_request_validation", True
                 )
             )
-            if validate_request and request.openapi_validated.errors:
+            request.environ["pyramid_openapi3.validate_response"] = asbool(
+                request.registry.settings.get(
+                    "pyramid_openapi3.enable_response_validation", True
+                )
+            )
+
+            # Request validation can happen already here, but response validation
+            # needs to happen later in a tween
+            if request.openapi_validated and request.openapi_validated.errors:
                 raise RequestValidationError(errors=request.openapi_validated.errors)
 
             # Do the view

--- a/pyramid_openapi3/tests/test_path_parameters.py
+++ b/pyramid_openapi3/tests/test_path_parameters.py
@@ -6,14 +6,8 @@ from tempfile import NamedTemporaryFile
 from webtest.app import TestApp
 
 
-class _FooResource:
-    def __init__(self, request: Request) -> None:
-        self.request = request
-        self.foo_id = request.openapi_validated.parameters["path"]["foo_id"]
-
-
-def _foo_view(context: _FooResource, request: Request) -> int:
-    return context.foo_id
+def _foo_view(request: Request) -> int:
+    return request.openapi_validated.parameters["path"]["foo_id"]
 
 
 def test_path_parameter_validation() -> None:
@@ -46,8 +40,10 @@ paths:
             config.include("pyramid_openapi3")
             config.pyramid_openapi3_spec(tempdoc.name)
             config.pyramid_openapi3_register_routes()
-            config.add_route("foo_route", "/foo/{foo_id}", factory=_FooResource)
-            config.add_view(_foo_view, route_name="foo_route", renderer="json")
+            config.add_route("foo_route", "/foo/{foo_id}")
+            config.add_view(
+                _foo_view, route_name="foo_route", renderer="json", openapi=True
+            )
             app = config.make_wsgi_app()
             test_app = TestApp(app)
             resp = test_app.get("/foo/1")

--- a/pyramid_openapi3/tween.py
+++ b/pyramid_openapi3/tween.py
@@ -30,8 +30,8 @@ def response_tween_factory(
         try:
             response = handler(request)
             if not request.environ.get("pyramid_openapi3.validate_response"):
-                # not an openapi view or response validation not requested
                 return response
+
             # validate response
             openapi_request = PyramidOpenAPIRequestFactory.create(request)
             openapi_response = PyramidOpenAPIResponseFactory.create(response)


### PR DESCRIPTION
Accessing `request.openapi_validated` in a route that has `view_config(openapi=False)` will no longer break the route.

Refs https://github.com/Pylons/pyramid_openapi3/issues/165