### PR TITLE
Add/multipart form data test

### DIFF
--- a/pyramid_openapi3/tests/test_contenttypes.py
+++ b/pyramid_openapi3/tests/test_contenttypes.py
@@ -1,0 +1,79 @@
+"""Test different request body content types."""
+
+from pyramid.config import Configurator
+from pyramid.request import Request
+from pyramid.router import Router
+from webtest.app import TestApp
+
+import tempfile
+import typing as t
+import unittest
+
+
+def app(spec: str, view: t.Callable, route: str) -> Router:
+    """Prepare a Pyramid app."""
+    with Configurator() as config:
+        config.include("pyramid_openapi3")
+        config.pyramid_openapi3_spec(spec)
+        config.add_route("foo", route)
+        config.add_view(openapi=True, renderer="json", view=view, route_name="foo")
+        return config.make_wsgi_app()
+
+
+OPENAPI_YAML = """
+    openapi: "3.0.0"
+    info:
+      version: "1.0.0"
+      title: Foo
+    components:
+      schemas:
+        ObjectWithName:
+          type: object
+          properties:
+            bar:
+              type: string
+    paths:
+      /foo:
+        post:
+          requestBody:
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/ObjectWithName"
+              application/x-www-form-urlencoded:
+                schema:
+                  $ref: "#/components/schemas/ObjectWithName"
+          responses:
+            200:
+              description: OK
+"""
+
+
+class TestContentTypes(unittest.TestCase):
+    """A suite of tests that make sure different body content types are supported."""
+
+    def _testapp(self) -> TestApp:
+        """Start up the app so that tests can send requests to it."""
+        from webtest import TestApp
+
+        def foo_view(request: Request) -> t.Dict[str, str]:
+            """Return reversed string."""
+            return {"bar": request.openapi_validated.body["bar"][::-1]}
+
+        with tempfile.NamedTemporaryFile() as document:
+            document.write(OPENAPI_YAML.encode())
+            document.seek(0)
+
+            return TestApp(app(document.name, foo_view, "/foo"))
+
+    def test_post_json(self) -> None:
+        """Post with `application/json`."""
+
+        res = self._testapp().post_json("/foo", {"bar": "baz"}, status=200)
+        self.assertEqual(res.json, {"bar": "zab"})
+
+    def test_post_form(self) -> None:
+        """Post with `application/x-www-form-urlencoded`."""
+
+        res = self._testapp().post("/foo", params={"bar": "baz"}, status=200)
+        self.assertEqual(res.json, {"bar": "zab"})

--- a/pyramid_openapi3/tests/test_contenttypes.py
+++ b/pyramid_openapi3/tests/test_contenttypes.py
@@ -43,9 +43,14 @@ OPENAPI_YAML = """
               application/x-www-form-urlencoded:
                 schema:
                   $ref: "#/components/schemas/ObjectWithName"
+              multipart/form-data:
+                schema:
+                  $ref: "#/components/schemas/ObjectWithName"
           responses:
             200:
               description: OK
+            400:
+              description: Bad Request
 """
 
 
@@ -76,4 +81,15 @@ class TestContentTypes(unittest.TestCase):
         """Post with `application/x-www-form-urlencoded`."""
 
         res = self._testapp().post("/foo", params={"bar": "baz"}, status=200)
+        self.assertEqual(res.json, {"bar": "zab"})
+
+    def test_post_form_multipart(self) -> None:
+        """Post with `multipart/form-data`."""
+
+        res = self._testapp().post(
+            "/foo",
+            params={"bar": "baz"},
+            content_type="multipart/form-data",
+            status=200,
+        )
         self.assertEqual(res.json, {"bar": "zab"})


### PR DESCRIPTION
Based on https://github.com/Pylons/pyramid_openapi3/pull/195

I added also a test for `multipart/form-data` which seems to fail at the moment.

I encountered this issue when updating a project that had ancient requirements but worked with those.
```
pyramid-openapi3 <= 0.14.0
openapi-core <= 0.16.7
openapi-schema-validator <= 0.2.3
openapi-spec-validator <= 0.4.0
```

I don't know exactly what has broken and where, but definitely `openapi-core 0.16.8` changed something.

With these versions the form data was processed. Now it fails to deserialize unless I add a custom deserializer which turns the data into json-serializable dict. I wouldn't want to do this for several reasons:

1. Unnecessarily complicated, should work out-of-the-box
2. Requires custom handling of more complicated data types
3. File data in the forms which turn into `cgi.FieldStorage `objects used to contain streamable `BytesIO` objects which could be nicely processed in business logic in small chunks. With custom deserializaer I had to convert it into string before OpenAPI validation would pass. Maybe there'd be a better workaround but I'd of course prefer to get the issue fixed instead.
