### PR TITLE
Protocol and port control

### DIFF
--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -155,6 +155,7 @@ def add_explorer_view(
     permission: str = NO_PERMISSION_REQUIRED,
     apiname: str = "pyramid_openapi3",
     proto_port: t.Tuple[str, int] = None,
+    host: str = None,
 ) -> None:
     """Serve Swagger UI at `route` url path.
 
@@ -164,6 +165,7 @@ def add_explorer_view(
     :param ui_version: Swagger UI version string
     :param permission: Permission for the explorer view
     :proto_port: Internet protocol and port for the specification URL
+    :host: Host of the specification URL
     """
 
     def register() -> None:
@@ -179,10 +181,16 @@ def add_explorer_view(
             with open(resolved_template.abspath()) as f:
                 template = Template(f.read())
                 if proto_port:
-                    html = template.safe_substitute(
-                        ui_version=ui_version,
-                        spec_url=request.route_url(settings[apiname]["spec_route_name"], _scheme=proto_port[0], _port=proto_port[1]),
-                    )
+                    if host:
+                        html = template.safe_substitute(
+                            ui_version=ui_version,
+                            spec_url=request.route_url(settings[apiname]["spec_route_name"], _scheme=proto_port[0], _port=proto_port[1], _host=host),
+                        )
+                    else:
+                        html = template.safe_substitute(
+                            ui_version=ui_version,
+                            spec_url=request.route_url(settings[apiname]["spec_route_name"], _scheme=proto_port[0], _port=proto_port[1]),
+                        )
                 else:
                     html = template.safe_substitute(
                         ui_version=ui_version,

--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -154,6 +154,7 @@ def add_explorer_view(
     ui_version: str = "4.15.5",
     permission: str = NO_PERMISSION_REQUIRED,
     apiname: str = "pyramid_openapi3",
+    proto_port: t.Tuple[str, int] = None,
 ) -> None:
     """Serve Swagger UI at `route` url path.
 
@@ -162,6 +163,7 @@ def add_explorer_view(
     :param template: Dotted path to the html template that renders Swagger UI response
     :param ui_version: Swagger UI version string
     :param permission: Permission for the explorer view
+    :proto_port: Internet protocol and port for the specification URL
     """
 
     def register() -> None:
@@ -176,10 +178,16 @@ def add_explorer_view(
                 )
             with open(resolved_template.abspath()) as f:
                 template = Template(f.read())
-                html = template.safe_substitute(
-                    ui_version=ui_version,
-                    spec_url=request.route_url(settings[apiname]["spec_route_name"]),
-                )
+                if proto_port:
+                    html = template.safe_substitute(
+                        ui_version=ui_version,
+                        spec_url=request.route_url(settings[apiname]["spec_route_name"], _scheme=proto_port[0], _port=proto_port[1]),
+                    )
+                else:
+                    html = template.safe_substitute(
+                        ui_version=ui_version,
+                        spec_url=request.route_url(settings[apiname]["spec_route_name"]),
+                    )
             return Response(html)
 
         config.add_route(route_name, route)


### PR DESCRIPTION
Based on issue #176.

I added a parameter in the `add_explorer_view`, so that it is possible to define the protocol (e.g. https instead of http) in the specification url. In such case, the port of the application also needs to be given in the `route_url` function of pyramid Request object, that's why the added parameter is a tuple of two values.