### PR TITLE
Add support for setting a prefix for auto-generated routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ This is equal to manually writing the following:
 config.add_route("foo_route", pattern="/foo")
 ```
 
+The `pyramid_openapi3_register_routes()` method supports setting a factory and route prefix as well. See the source for details.
+
 ## Demo / Examples
 
 There are three examples provided with this package:

--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -342,6 +342,7 @@ def register_routes(
     route_name_ext: str = "x-pyramid-route-name",
     root_factory_ext: str = "x-pyramid-root-factory",
     apiname: str = "pyramid_openapi3",
+    route_prefix: t.Optional[str] = None,
 ) -> None:
     """Register routes to app from OpenApi 3.0 specification.
 
@@ -357,7 +358,9 @@ def register_routes(
                 root_factory = path_item.get(root_factory_ext)
                 config.add_route(
                     route_name,
-                    pattern=pattern,
+                    pattern=route_prefix + pattern
+                    if route_prefix is not None
+                    else pattern,
                     factory=root_factory or None,
                 )
 

--- a/pyramid_openapi3/tests/test_contenttypes.py
+++ b/pyramid_openapi3/tests/test_contenttypes.py
@@ -1,0 +1,79 @@
+"""Test different request body content types."""
+
+from pyramid.config import Configurator
+from pyramid.request import Request
+from pyramid.router import Router
+from webtest.app import TestApp
+
+import tempfile
+import typing as t
+import unittest
+
+
+def app(spec: str, view: t.Callable, route: str) -> Router:
+    """Prepare a Pyramid app."""
+    with Configurator() as config:
+        config.include("pyramid_openapi3")
+        config.pyramid_openapi3_spec(spec)
+        config.add_route("foo", route)
+        config.add_view(openapi=True, renderer="json", view=view, route_name="foo")
+        return config.make_wsgi_app()
+
+
+OPENAPI_YAML = """
+    openapi: "3.0.0"
+    info:
+      version: "1.0.0"
+      title: Foo
+    components:
+      schemas:
+        FooObject:
+          type: object
+          properties:
+            bar:
+              type: string
+    paths:
+      /foo:
+        post:
+          requestBody:
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/FooObject"
+              application/x-www-form-urlencoded:
+                schema:
+                  $ref: "#/components/schemas/FooObject"
+          responses:
+            200:
+              description: OK
+"""
+
+
+class TestContentTypes(unittest.TestCase):
+    """A suite of tests that make sure different body content types are supported."""
+
+    def _testapp(self) -> TestApp:
+        """Start up the app so that tests can send requests to it."""
+        from webtest import TestApp
+
+        def foo_view(request: Request) -> t.Dict[str, str]:
+            """Return reversed string."""
+            return {"bar": request.openapi_validated.body["bar"][::-1]}
+
+        with tempfile.NamedTemporaryFile() as document:
+            document.write(OPENAPI_YAML.encode())
+            document.seek(0)
+
+            return TestApp(app(document.name, foo_view, "/foo"))
+
+    def test_post_json(self) -> None:
+        """Post with `application/json`."""
+
+        res = self._testapp().post_json("/foo", {"bar": "baz"}, status=200)
+        self.assertEqual(res.json, {"bar": "zab"})
+
+    def test_post_form(self) -> None:
+        """Post with `application/x-www-form-urlencoded`."""
+
+        res = self._testapp().post("/foo", params={"bar": "baz"}, status=200)
+        self.assertEqual(res.json, {"bar": "zab"})

--- a/pyramid_openapi3/tests/test_routes.py
+++ b/pyramid_openapi3/tests/test_routes.py
@@ -40,7 +40,17 @@ paths:
             config.pyramid_openapi3_spec(tempdoc.name)
             config.pyramid_openapi3_register_routes()
             config.add_route("bar", "/bar")
-            config.make_wsgi_app()
+            app = config.make_wsgi_app()
+
+    routes = [
+        (i["introspectable"]["name"], i["introspectable"]["pattern"])
+        for i in app.registry.introspector.get_category("routes")
+    ]
+    assert routes == [
+        ("pyramid_openapi3.spec", "/openapi.yaml"),
+        ("foo", "/foo"),
+        ("bar", "/bar"),
+    ]
 
 
 def test_register_routes_with_factory() -> None:
@@ -57,7 +67,56 @@ info:
 paths:
   /foo:
     x-pyramid-route-name: foo
+    get:
+      responses:
+        200:
+          description: A foo
+  /bar:
+    x-pyramid-route-name: bar
     x-pyramid-root-factory: pyramid_openapi3.tests.test_routes.dummy_factory
+    get:
+      responses:
+        200:
+          description: A bar
+
+"""
+            )
+            tempdoc.seek(0)
+            config.pyramid_openapi3_spec(tempdoc.name)
+            config.pyramid_openapi3_register_routes()
+            app = config.make_wsgi_app()
+
+    routes = [
+        (
+            i["introspectable"]["name"],
+            i["introspectable"]["pattern"],
+            i["introspectable"]["factory"],
+        )
+        for i in app.registry.introspector.get_category("routes")
+    ]
+    assert routes == [
+        ("pyramid_openapi3.spec", "/openapi.yaml", None),
+        ("foo", "/foo", None),
+        ("bar", "/bar", dummy_factory),
+    ]
+
+
+def test_register_routes_with_prefix() -> None:
+    """Test registration routes with route_prefix."""
+    with testConfig() as config:
+        config.include("pyramid_openapi3")
+        with tempfile.NamedTemporaryFile() as tempdoc:
+            tempdoc.write(
+                b"""\
+openapi: "3.0.0"
+info:
+  version: "1.0.0"
+  title: Foo API
+servers:
+  - url: /api/v1
+paths:
+  /foo:
+    x-pyramid-route-name: foo
     get:
       responses:
         200:
@@ -66,5 +125,14 @@ paths:
             )
             tempdoc.seek(0)
             config.pyramid_openapi3_spec(tempdoc.name)
-            config.pyramid_openapi3_register_routes()
-            config.make_wsgi_app()
+            config.pyramid_openapi3_register_routes(route_prefix="/api/v1")
+            app = config.make_wsgi_app()
+
+    routes = [
+        (i["introspectable"]["name"], i["introspectable"]["pattern"])
+        for i in app.registry.introspector.get_category("routes")
+    ]
+    assert routes == [
+        ("pyramid_openapi3.spec", "/openapi.yaml"),
+        ("foo", "/api/v1/foo"),
+    ]


### PR DESCRIPTION
Also, add a test to verify 'application/x-www-form-urlencoded' is supported, which closes https://github.com/Pylons/pyramid_openapi3/pull/195.