### PR TITLE
chore: update versions of GitHub Actions

### DIFF
--- a/.github/actions/nix-shell/action.yml
+++ b/.github/actions/nix-shell/action.yml
@@ -10,10 +10,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: cachix/install-nix-action@v20
+    - uses: cachix/install-nix-action@v26
       with:
         nix_path: nixpkgs=channel:nixos-unstable
-    - uses: cachix/cachix-action@v12
+    - uses: cachix/cachix-action@v14
       with:
         name: pyramid-openapi3
         authToken: '${{ inputs.cachix_auth_token }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: htmlcov
-          path: htmlcov
+          path: htmlcov/
 
   test_39:
     name: "Python 3.9 Tests"
@@ -96,8 +96,8 @@ jobs:
       - name: Save coverage report
         uses: actions/upload-artifact@v4
         with:
-          name: htmlcov
-          path: htmlcov
+          name: htmlcov-py39
+          path: htmlcov/
 
 
   release:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/nix-shell
         with:
           cachix_auth_token: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -58,7 +58,7 @@ jobs:
           nix-shell --run "python -m unittest tests.py"
 
       - name: Save coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: htmlcov
           path: htmlcov
@@ -69,7 +69,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/nix-shell
         with:
           cachix_auth_token: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -94,7 +94,7 @@ jobs:
           nix-shell --run "python3.9 -m unittest tests.py"
 
       - name: Save coverage report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: htmlcov
           path: htmlcov


### PR DESCRIPTION
These are using deprecated runtimes.
See: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/