### PR TITLE
Spec as absolute path not absolute URI

### DIFF
--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -149,7 +149,6 @@ def add_explorer_view(
     ui_version: str = "5.12.0",
     permission: str = NO_PERMISSION_REQUIRED,
     apiname: str = "pyramid_openapi3",
-    proto_port: t.Optional[t.Tuple[str, int]] = None,
 ) -> None:
     """Serve Swagger UI at `route` url path.
 
@@ -158,7 +157,6 @@ def add_explorer_view(
     :param template: Dotted path to the html template that renders Swagger UI response
     :param ui_version: Swagger UI version string
     :param permission: Permission for the explorer view
-    :proto_port: Internet protocol and port for the specification URL
     """
 
     def register() -> None:
@@ -172,19 +170,10 @@ def add_explorer_view(
                     "to work."
                 )
             with open(resolved_template.abspath()) as f:
-                if proto_port:
-                    spec_url = request.route_url(
-                        settings[apiname]["spec_route_name"],
-                        _scheme=proto_port[0],
-                        _port=proto_port[1],
-                    )
-                else:
-                    spec_url = request.route_url(settings[apiname]["spec_route_name"])
-
                 template = Template(f.read())
                 html = template.safe_substitute(
                     ui_version=ui_version,
-                    spec_url=spec_url,
+                    spec_url=request.route_url(settings[apiname]["spec_route_name"]),
                 )
             return Response(html)
 

--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -173,7 +173,7 @@ def add_explorer_view(
                 template = Template(f.read())
                 html = template.safe_substitute(
                     ui_version=ui_version,
-                    spec_url=request.route_url(settings[apiname]["spec_route_name"]),
+                    spec_url=request.route_path(settings[apiname]["spec_route_name"]),
                 )
             return Response(html)
 

--- a/pyramid_openapi3/tests/test_views.py
+++ b/pyramid_openapi3/tests/test_views.py
@@ -303,33 +303,6 @@ def test_add_explorer_view() -> None:
         assert b"<title>Swagger UI</title>" in response.body
 
 
-def test_add_explorer_view_custom_proto_port() -> None:
-    """Test serving Swagger UI on a custom protocol and port."""
-    with testConfig() as config:
-        config.include("pyramid_openapi3")
-
-        with tempfile.NamedTemporaryFile() as document:
-            document.write(MINIMAL_DOCUMENT)
-            document.seek(0)
-
-            config.pyramid_openapi3_spec(
-                document.name, route="/foo.yaml", route_name="foo_api_spec"
-            )
-
-        config.pyramid_openapi3_add_explorer(proto_port=("https", 6543))
-        request = config.registry.queryUtility(
-            IRouteRequest, name="pyramid_openapi3.explorer"
-        )
-        view = config.registry.adapters.registered(
-            (IViewClassifier, request, Interface), IView, name=""
-        )
-        request = DummyRequest(config=config)
-        request.environ["SERVER_NAME"] = "example.com"
-        response = view(request=request, context=None)
-        assert b"<title>Swagger UI</title>" in response.body
-        assert b"https://example.com:6543/foo.yaml" in response.body
-
-
 def test_add_multiple_explorer_views() -> None:
     """Test registration of multiple views serving different Swagger UI."""
     with testConfig() as config:

--- a/pyramid_openapi3/tests/test_views.py
+++ b/pyramid_openapi3/tests/test_views.py
@@ -344,7 +344,7 @@ def test_add_multiple_explorer_views() -> None:
         )
         response = view(request=DummyRequest(config=config), context=None)
         assert b"<title>Swagger UI</title>" in response.body
-        assert b"http://example.com/foo/openapi.yaml" in response.body
+        assert b'url: "/foo/openapi.yaml"' in response.body
 
         request = config.registry.queryUtility(IRouteRequest, name="bar_api_explorer")
         view = config.registry.adapters.registered(
@@ -352,7 +352,7 @@ def test_add_multiple_explorer_views() -> None:
         )
         response = view(request=DummyRequest(config=config), context=None)
         assert b"<title>Swagger UI</title>" in response.body
-        assert b"http://example.com/bar/openapi.yaml" in response.body
+        assert b'url: "/bar/openapi.yaml"' in response.body
 
 
 def test_add_multiple_explorer_views_using_directory() -> None:
@@ -398,7 +398,7 @@ def test_add_multiple_explorer_views_using_directory() -> None:
         )
         response = view(request=DummyRequest(config=config), context=None)
         assert b"<title>Swagger UI</title>" in response.body
-        assert b"http://example.com/foo.yaml" in response.body
+        assert b'url: "/foo.yaml"' in response.body
 
         request = config.registry.queryUtility(IRouteRequest, name="bar_api_explorer")
         view = config.registry.adapters.registered(
@@ -406,7 +406,7 @@ def test_add_multiple_explorer_views_using_directory() -> None:
         )
         response = view(request=DummyRequest(config=config), context=None)
         assert b"<title>Swagger UI</title>" in response.body
-        assert b"http://example.com/bar.yaml" in response.body
+        assert b'url: "/bar.yaml"' in response.body
 
 
 def test_explorer_view_missing_spec() -> None:


### PR DESCRIPTION
This should resolve any issues one might have with serving Swagger UI behind a reverse proxy where protocols or ports change, without any additional configuration.

Fixes: #176
Refs: #207