### PR TITLE
fix(extract_errors): fix wrong field being emitted when extracting several errors for a single object

### DIFF
--- a/pyramid_openapi3/exceptions.py
+++ b/pyramid_openapi3/exceptions.py
@@ -69,7 +69,7 @@ class ImproperAPISpecificationWarning(UserWarning):
 
 
 def extract_errors(
-    request: Request, errors: t.List[OpenAPIError], field: t.Optional[str] = None
+    request: Request, errors: t.List[OpenAPIError], parent_field: t.Optional[str] = None
 ) -> t.Iterator[t.Dict[str, str]]:
     """Extract errors for JSON response.
 
@@ -129,7 +129,7 @@ def extract_errors(
 
         output.update({"message": message})
 
-        field = getattr(err, "field", field)
+        field = getattr(err, "field", parent_field)
         if field is None:
             field = getattr(err, "name", None)
         if field is None and getattr(err, "validator", None) == "required":

--- a/pyramid_openapi3/tests/test_extract_errors.py
+++ b/pyramid_openapi3/tests/test_extract_errors.py
@@ -397,7 +397,7 @@ class BadRequestsTests(unittest.TestCase):
             {
                 "exception": "ParameterValidationError",
                 "message": "Failed to cast value to integer type: abc",
-                "field": "bar",
+                "field": "bam",
             },
             {
                 "exception": "ValidationError",


### PR DESCRIPTION
The `field` variable was used both as the function argument and as a local variable that was not intended to be reused between iterations.

Renaming the function argument fixes this problem since its value is no longer modified between iterations.

You can take a look at the test BadRequestsTests.test_multiple_errors  which contained an inconsistency :
a string was passed as value for the "bam" parameter whose schema was typed as "integer". The error was reported on "baz" instead of "bam".