### PR TITLE
support custom swagger config and oauth redirects

### DIFF
--- a/pyramid_openapi3/static/index.html
+++ b/pyramid_openapi3/static/index.html
@@ -69,22 +69,23 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/swagger-ui/${ui_version}/swagger-ui-standalone-preset.js"> </script>
 <script>
     window.onload = function() {
-        // Build a system
-        const ui = SwaggerUIBundle({
-            url: "${spec_url}",
-            dom_id: '#swagger-ui',
-            deepLinking: true,
+        const uiConfig = ${ui_config};
+        Object.assign(uiConfig, {
             presets: [
                 SwaggerUIBundle.presets.apis,
-                SwaggerUIStandalonePreset
+                SwaggerUIStandalonePreset,
             ],
             plugins: [
-                SwaggerUIBundle.plugins.DownloadUrl
+                SwaggerUIBundle.plugins.DownloadUrl,
             ],
-            validatorUrl: null,
-            layout: "StandaloneLayout"
-        })
-        window.ui = ui
+        };
+        const oauthConfig = ${oauth_config};
+        // Build a system
+        const ui = SwaggerUIBundle(uiConfig);
+        if (oauthConfig) {
+            ui.initOAuth(oauthConfig);
+        }
+        window.ui = ui;
     }
 </script>
 </body>

--- a/pyramid_openapi3/static/oauth2-redirect.html
+++ b/pyramid_openapi3/static/oauth2-redirect.html
@@ -1,0 +1,79 @@
+<!doctype html>
+<html lang="en-US">
+<head>
+    <title>Swagger UI: OAuth2 Redirect</title>
+</head>
+<body>
+<script>
+    'use strict';
+    function run () {
+        var oauth2 = window.opener.swaggerUIRedirectOauth2;
+        var sentState = oauth2.state;
+        var redirectUrl = oauth2.redirectUrl;
+        var isValid, qp, arr;
+
+        if (/code|token|error/.test(window.location.hash)) {
+            qp = window.location.hash.substring(1).replace('?', '&');
+        } else {
+            qp = location.search.substring(1);
+        }
+
+        arr = qp.split("&");
+        arr.forEach(function (v,i,_arr) { _arr[i] = '"' + v.replace('=', '":"') + '"';});
+        qp = qp ? JSON.parse('{' + arr.join() + '}',
+                function (key, value) {
+                    return key === "" ? value : decodeURIComponent(value);
+                }
+        ) : {};
+
+        isValid = qp.state === sentState;
+
+        if ((
+          oauth2.auth.schema.get("flow") === "accessCode" ||
+          oauth2.auth.schema.get("flow") === "authorizationCode" ||
+          oauth2.auth.schema.get("flow") === "authorization_code"
+        ) && !oauth2.auth.code) {
+            if (!isValid) {
+                oauth2.errCb({
+                    authId: oauth2.auth.name,
+                    source: "auth",
+                    level: "warning",
+                    message: "Authorization may be unsafe, passed state was changed in server. The passed state wasn't returned from auth server."
+                });
+            }
+
+            if (qp.code) {
+                delete oauth2.state;
+                oauth2.auth.code = qp.code;
+                oauth2.callback({auth: oauth2.auth, redirectUrl: redirectUrl});
+            } else {
+                let oauthErrorMsg;
+                if (qp.error) {
+                    oauthErrorMsg = "["+qp.error+"]: " +
+                        (qp.error_description ? qp.error_description+ ". " : "no accessCode received from the server. ") +
+                        (qp.error_uri ? "More info: "+qp.error_uri : "");
+                }
+
+                oauth2.errCb({
+                    authId: oauth2.auth.name,
+                    source: "auth",
+                    level: "error",
+                    message: oauthErrorMsg || "[Authorization failed]: no accessCode received from the server."
+                });
+            }
+        } else {
+            oauth2.callback({auth: oauth2.auth, token: qp, isValid: isValid, redirectUrl: redirectUrl});
+        }
+        window.close();
+    }
+
+    if (document.readyState !== 'loading') {
+        run();
+    } else {
+        document.addEventListener('DOMContentLoaded', function () {
+            run();
+        });
+    }
+</script>
+</body>
+</html>

--- a/pyramid_openapi3/tests/test_views.py
+++ b/pyramid_openapi3/tests/test_views.py
@@ -310,7 +310,7 @@ def test_add_explorer_view() -> None:
 
 
 def test_add_explorer_oauth_view() -> None:
-    """Test registration of a view serving the Swagger UI."""
+    """Test registration of a view serving the Swagger UI with OAuth support."""
     with testConfig() as config:
         config.include("pyramid_openapi3")
 


### PR DESCRIPTION
These are all explorer features:

- Added a new `ui_config` parameter to add extra options to the `SwaggerUI` constructor. Obviously you can't configure everything but it allows some support.
- Added a new `enable_oauth_redirect` boolean which will enable and start serving the `oauth2-redirect.html` which is required for a proper oauth2 flow through the swagger UI.
- Added a new `oauth_config` which will invoke the `ui.initOAuth` API on the `SwaggerUI` which is necessary to enable things like the PKCE challenge flow that is managed automatically by the `oauth2-redirect` HTML.

Fixes https://github.com/Pylons/pyramid_openapi3/issues/261.

This enables the following dummy example to work against Azure AD:

```python
import jwt
import requests
from pyramid.config import Configurator
from pyramid.httpexceptions import HTTPForbidden
from pyramid.view import view_config
from waitress import serve

tenant_id = '...'
client_id = '...'
scopes = [
    f'{tenant_id}/.default'
]
oidc_config_url = f'https://login.microsoftonline.com/{tenant_id}/v2.0/.well-known/openid-configuration'

oidc_config = requests.get(oidc_config_url).json()
jwks_client = jwt.PyJWKClient(oidc_config['jwks_uri'])

@view_config(route_name='/userinfo', renderer='json')
def userinfo(request):
    if request.authorization.authtype != 'Bearer':
        raise HTTPForbidden
    token = request.authorization.params
    signing_key = jwks_client.get_signing_key_from_jwt(token)
    signing_algorithms = oidc_config['id_token_signing_alg_values_supported']
    claims = jwt.decode(token, key=signing_key, algorithms=signing_algorithms, audience=client_id)
    return claims


with Configurator() as config:
    config.include('pyramid_openapi3')

    config.pyramid_openapi3_spec('openapi.yaml', route='openapi.yaml')
    config.pyramid_openapi3_add_explorer(
        oauth_config={
            'clientId': client_id,
            'scopes': ' '.join(scopes),
            'usePkceWithAuthorizationCodeGrant': True,
        },
    )

    config.add_route('/userinfo', '/userinfo')

    config.scan(__name__)
    app = config.make_wsgi_app()

serve(app, listen='localhost:8000')
```

Example `openapi.yaml`:

```yaml
openapi: 3.1.0
info:
  title: My Awesome API
  version: 0.1.0
paths:
  /userinfo:
    get:
      summary: Userinfo
      responses:
        "200":
          description: Successful Response
          content:
            application/json:
              schema: {}
      security:
        - azure: []
components:
  securitySchemes:
    azure:
      type: oauth2
      flows:
        authorizationCode:
          scopes:
            <client_id>/.default: 'Required scope that indicates to Azure that this app is logging in. Without it the audience will be the Microsoft Graph API instead of us as the client.'
          authorizationUrl: https://login.microsoftonline.com/<tenant_id>/oauth2/v2.0/authorize
          tokenUrl: https://login.microsoftonline.com/<tenant_id>/oauth2/v2.0/token
```