### PR TITLE
allow the app to be hosted at a prefix in script_name but still validate against allowed servers

### DIFF
--- a/pyramid_openapi3/tests/test_wrappers.py
+++ b/pyramid_openapi3/tests/test_wrappers.py
@@ -69,7 +69,7 @@ def test_relative_app_request() -> None:
     )
     assert openapi_request.host_url == "http://example.com"
     assert openapi_request.path == "/subpath/foo"
-    assert openapi_request.path_pattern == "/foo"
+    assert openapi_request.path_pattern == "/subpath/foo"
     assert openapi_request.method == "get"
     assert openapi_request.body == b""
     assert openapi_request.mimetype == "text/html"

--- a/pyramid_openapi3/wrappers.py
+++ b/pyramid_openapi3/wrappers.py
@@ -41,7 +41,7 @@ class PyramidOpenAPIRequest:
             if self.request.matched_route
             else self.request.path_info
         )
-        return path_pattern
+        return self.request.script_name + path_pattern
 
     @property
     def method(self) -> str:


### PR DESCRIPTION
If you use rutter or anything else to host a WSGI app at a path prefix then you'll have a non-empty `request.script_name`. This hasn't previously been supported in pyramid_openapi3 because the `path_pattern` did not have the prefix included.

The openapi-core is expecting that `urljoin(host_url, path_pattern)` results in a url that matches something in the servers section + a path in the paths section.

The new script_name based test cases fail without the one-line fix.

Replaces #244.
Fixes https://github.com/Pylons/pyramid_openapi3/issues/104.