### PR TITLE
Validate responses without unmarshalling

### DIFF
--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -6,10 +6,10 @@ from .exceptions import RequestValidationError
 from .exceptions import ResponseValidationError
 from .wrappers import PyramidOpenAPIRequest
 from jsonschema_path import SchemaPath
+from openapi_core import V30ResponseValidator
+from openapi_core import V31ResponseValidator
 from openapi_core.unmarshalling.request import V30RequestUnmarshaller
 from openapi_core.unmarshalling.request import V31RequestUnmarshaller
-from openapi_core.unmarshalling.response import V30ResponseUnmarshaller
-from openapi_core.unmarshalling.response import V31ResponseUnmarshaller
 from openapi_core.validation.request.exceptions import SecurityValidationError
 from openapi_spec_validator import validate
 from openapi_spec_validator.readers import read_from_filename
@@ -362,18 +362,18 @@ def _create_api_settings(
         "pyramid_openapi3_unmarshallers"
     )
 
-    # switch unmarshaller based on spec version
+    # switch validator based on spec version
     spec_version = get_spec_version(spec.contents())
     request_unmarshallers = {
         "OpenAPIV3.0": V30RequestUnmarshaller,
         "OpenAPIV3.1": V31RequestUnmarshaller,
     }
-    response_unmarshallers = {
-        "OpenAPIV3.0": V30ResponseUnmarshaller,
-        "OpenAPIV3.1": V31ResponseUnmarshaller,
+    response_validators = {
+        "OpenAPIV3.0": V30ResponseValidator,
+        "OpenAPIV3.1": V31ResponseValidator,
     }
     request_unmarshaller = request_unmarshallers[str(spec_version)]
-    response_unmarshaller = response_unmarshallers[str(spec_version)]
+    response_validator = response_validators[str(spec_version)]
 
     return {
         "filepath": filepath,
@@ -385,11 +385,10 @@ def _create_api_settings(
             extra_media_type_deserializers=custom_deserializers,
             extra_format_unmarshallers=custom_unmarshallers,
         ),
-        "response_validator": response_unmarshaller(
+        "response_validator": response_validator(
             spec,
             extra_format_validators=custom_formatters,
             extra_media_type_deserializers=custom_deserializers,
-            extra_format_unmarshallers=custom_unmarshallers,
         ),
     }
 

--- a/pyramid_openapi3/tween.py
+++ b/pyramid_openapi3/tween.py
@@ -41,11 +41,13 @@ def response_tween_factory(
             if "routes" in gsettings:
                 settings_key = gsettings["routes"][request.matched_route.name]
                 settings = request.registry.settings[settings_key]
-            result = settings["response_validator"].unmarshal(
-                request=openapi_request, response=openapi_response
+            errors = list(
+                settings["response_validator"].iter_errors(
+                    request=openapi_request, response=openapi_response
+                )
             )
             request_validated = request.environ.get("pyramid_openapi3.validate_request")
-            if result.errors:
+            if errors:
                 if request_validated and request.openapi_validated.errors:
                     warnings.warn_explicit(
                         ImproperAPISpecificationWarning(
@@ -61,7 +63,7 @@ def response_tween_factory(
                         registry.settings[settings_key]["filepath"],
                         0,
                     )
-                raise ResponseValidationError(response=response, errors=result.errors)
+                raise ResponseValidationError(response=response, errors=errors)
 
         # If there is no exception view, we also see request validation errors here
         except ResponseValidationError:


### PR DESCRIPTION
Response validation only needs to collect conformance errors; the tween never uses unmarshalled values. Validation still happens, but response unmarshalling is skipped.

We discovered that response-side unmarshal rebuilds response data by walking nested response schemas and array items, which can create a large repeated validation loop for big payloads. In practice, that loop can take significant time even though pyramid_openapi3 discards the unmarshalled value.

This swaps response-side setup to V30ResponseValidator/V31ResponseValidator and calls iter_errors(), leaving request unmarshalling unchanged.