### PR TITLE
fix(dev): minor leftovers from tool migration

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,16 +40,16 @@ make tests
 If you don't use Nix, install the tools yourself:
 
 ```shell
-uv tool install prek            # pre-commit hook runner
-uv tool install ruff            # Python linter and formatter
-uv tool install ty              # Python type checker
-uv tool install codespell       # spell checker
-uv tool install detect-secrets  # secret scanner
-uv tool install tombi           # TOML formatter
-uv tool install zizmor          # GitHub Actions auditor
-brew install actionlint         # GitHub Actions linter
-brew install shellcheck         # shell script linter
-brew install yamlfmt            # YAML formatter
+uv tool install prek                         # pre-commit hook runner
+uv tool install ruff                         # Python linter and formatter
+uv tool install ty                           # Python type checker
+uv tool install codespell                    # spell checker
+uv tool install 'detect-secrets[gibberish]'  # secret scanner
+uv tool install tombi                        # TOML formatter
+uv tool install zizmor                       # GitHub Actions auditor
+brew install actionlint                      # GitHub Actions linter
+brew install shellcheck                      # shell script linter
+brew install yamlfmt                         # YAML formatter
 ```
 
 (`brew` works on both macOS and Linux; your distro's package manager has these too.)

--- a/shell.nix
+++ b/shell.nix
@@ -20,6 +20,7 @@ pkgs.mkShell {
 
     # Linters and formatters used by the pre-commit hooks
     actionlint
+    cacert
     codespell
     deadnix
     detect-secrets


### PR DESCRIPTION
- Installing `detect-secrets` on its own doesn't include the required `gibberish` dependency to run 
  Refs: https://github.com/NixOS/nixpkgs/blob/bd0ff2d3eac24699c3664d5966b9ef36f388e2ca/pkgs/development/python-modules/detect-secrets/default.nix#L34
  Refs: https://github.com/Yelp/detect-secrets/blob/5e141933554a0b74e7341841f318be21e895339c/setup.py#L46-L48
- Running `prek -a` in a pure nix shell fails to download hooks from https://github.com/pre-commit/pre-commit-hooks due to missing certificate bundle

Refs: #309