### PR TITLE
chore(actions): split up ci from release

### DIFF
--- a/.github/actions/nix-shell/action.yml
+++ b/.github/actions/nix-shell/action.yml
@@ -6,10 +6,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: cachix/install-nix-action@v26
+    - uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
       with:
         nix_path: nixpkgs=channel:nixos-unstable
-    - uses: cachix/cachix-action@v14
+    - uses: cachix/cachix-action@18cf96c7c98e048e10a83abd92116114cd8504be # v14
       with:
         name: pyramid-openapi3
         authToken: '${{ inputs.cachix_auth_token }}'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      uv:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - '*'
 # To SSH into the runner to debug a failure, add the following step before
 # the failing step
 #    - uses: lhotari/action-upterm@v1
@@ -26,7 +24,7 @@ jobs:
     name: "Python 3.14 Tests"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - uses: ./.github/actions/nix-shell
@@ -48,7 +46,7 @@ jobs:
           cd examples/splitfile
           nix-shell --run "uv run --no-sync python -m unittest tests"
       - name: Save coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: htmlcov
           path: htmlcov/
@@ -56,7 +54,7 @@ jobs:
     name: "Python 3.11 Tests (oldest supported dependencies)"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
       - uses: ./.github/actions/nix-shell
@@ -79,29 +77,3 @@ jobs:
         run: |
           cd examples/splitfile
           nix-shell --run "uv run --no-sync --python 3.11 python -m unittest tests"
-  release:
-    name: "Release to PyPI"
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
-    needs: [test_314, test_311]
-    runs-on: ubuntu-latest
-    env:
-      UV_PUBLISH_TOKEN: ${{ secrets.POETRY_PYPI_TOKEN_PYPI }}
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/nix-shell
-        with:
-          cachix_auth_token: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-      - name: verify git tag matches pyproject.toml version
-        run: |
-          PROJECT_VERSION=$(nix-shell --run "uv version --short")
-          echo "tag=$GITHUB_REF_NAME project=$PROJECT_VERSION"
-          [[ "$GITHUB_REF_NAME" == "$PROJECT_VERSION" ]] && exit 0 || exit 1
-      - run: nix-shell --run "uv build && uv publish"
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: gh release create "$GITHUB_REF_NAME" --generate-notes --latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,73 @@
+# Build, publish to PyPI, and attach artifacts when a GitHub Release is published.
+# Assumes CI has already passed on `main`; this workflow does not re-run tests.
+name: Release
+on:
+  release:
+    types: [published]
+# Never cancel an in-flight release.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+# Default to read-only; each job opts into the extra scope it needs.
+permissions:
+  contents: read
+jobs:
+  build:
+    name: "Build distribution"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/nix-shell
+        with:
+          cachix_auth_token: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - name: Verify git tag matches pyproject.toml version
+        run: |
+          PROJECT_VERSION=$(nix-shell --run "uv version --short")
+          echo "tag=$GITHUB_REF_NAME project=$PROJECT_VERSION"
+          [[ "$GITHUB_REF_NAME" == "$PROJECT_VERSION" ]] && exit 0 || exit 1
+      - name: Build sdist and wheel
+        run: nix-shell --run "uv build"
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+  publish:
+    name: "Publish to PyPI"
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pyramid_openapi3
+    permissions:
+      id-token: write # Trusted publishing uses OIDC token to mint short-lived PyPI API token
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI via trusted publishing
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+  github-release:
+    name: "Attach artifacts to release"
+    needs: [publish]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # Needed to create release and upload assets
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: dist
+          path: dist/
+      - name: Upload artifacts to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release upload "$GITHUB_REF_NAME" dist/* --clobber

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,7 +1,0 @@
-# Allow version-tag pins (ref-pin) for GitHub Actions rather than requiring
-# commit SHA hash-pins, matching the pinning style used across this repository.
-rules:
-  unpinned-uses:
-    config:
-      policies:
-        "*": ref-pin


### PR DESCRIPTION
Does a few things:

- splits apart ci from release, so that each PR doesn't see a skipped release step
- triggers release on release published, not tag, since now releases are driven via GitHub Draft New Release UI
- pins down each action to hash, removes zizmor overeride
- in release workflow, split apart build from publish to isolate dependencies from any pollution
- sets basics for Trusted Publishing (**needs configuration on PyPI-side**)
- adds a dependabot config to check in monthly and create a single PR per ecosystem