### PR TITLE
fix(dev): set an explicit path for uv project env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,7 @@ celerybeat-schedule
 # Environments
 .env
 .venv
+.venv-nix
 env/
 venv/
 ENV/

--- a/shell.nix
+++ b/shell.nix
@@ -38,4 +38,10 @@ pkgs.mkShell {
   # Use the Nix-provided interpreters instead of uv-managed downloads, which do
   # not run on NixOS without extra patching.
   UV_PYTHON_DOWNLOADS = "never";
+
+  # Keep this shell's venv separate from a host-created .venv. This matters when
+  # the project directory is bind-mounted into a NixOS VM (e.g. OrbStack): the
+  # host's .venv is still visible there, but built for a different OS/interpreter,
+  # so reusing it breaks `uv sync`/`uv run`.
+  UV_PROJECT_ENVIRONMENT = ".venv-nix";
 }


### PR DESCRIPTION
If unset and a `.venv` directory exists, the interpreter appears broken. This isolates the in-nixOS uv-based virtualenv from the external one.