### PR TITLE
chore(ci): update and pin all actions

### DIFF
--- a/.github/actions/nix-shell/action.yml
+++ b/.github/actions/nix-shell/action.yml
@@ -6,10 +6,10 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
+    - uses: cachix/install-nix-action@8aa03977d8d733052d78f4e008a241fd1dbf36b3 # v31.10.6
       with:
         nix_path: nixpkgs=channel:nixos-unstable
-    - uses: cachix/cachix-action@18cf96c7c98e048e10a83abd92116114cd8504be # v14
+    - uses: cachix/cachix-action@5f2d7c5294214f71b873db4b969586b980625e71 # v17
       with:
         name: pyramid-openapi3
         authToken: '${{ inputs.cachix_auth_token }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
       - main
 # To SSH into the runner to debug a failure, add the following step before
 # the failing step
-#    - uses: lhotari/action-upterm@v1
+#    - uses: lhotari/action-upterm@b0357f23233f5ea6d58947c0c402e0631bab7334 # v1
 #      with:
 #        limit-access-to-actor: true
 


### PR DESCRIPTION
`cachix/cachix-action` was emitting warnings for Node 20.

Unclear why dependabot wasn't updating these.