### PR TITLE
feat: support OpenAPI 3.2 specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pyramid_openapi3
 
-## Validate [Pyramid](https://trypyramid.com) views against [OpenAPI 3.0/3.1](https://swagger.io/specification/) documents
+## Validate [Pyramid](https://trypyramid.com) views against [OpenAPI 3.0/3.1/3.2](https://swagger.io/specification/) documents
 
 <p align="center">
   <img alt="Pyramid and OpenAPI logos"

--- a/pyramid_openapi3/__init__.py
+++ b/pyramid_openapi3/__init__.py
@@ -8,8 +8,10 @@ from .wrappers import PyramidOpenAPIRequest
 from jsonschema_path import SchemaPath
 from openapi_core import V30ResponseValidator
 from openapi_core import V31ResponseValidator
+from openapi_core import V32ResponseValidator
 from openapi_core.unmarshalling.request import V30RequestUnmarshaller
 from openapi_core.unmarshalling.request import V31RequestUnmarshaller
+from openapi_core.unmarshalling.request import V32RequestUnmarshaller
 from openapi_core.validation.request.exceptions import SecurityValidationError
 from openapi_spec_validator import validate
 from openapi_spec_validator.readers import read_from_filename
@@ -364,10 +366,12 @@ def _create_api_settings(
     request_unmarshallers = {
         "OpenAPIV3.0": V30RequestUnmarshaller,
         "OpenAPIV3.1": V31RequestUnmarshaller,
+        "OpenAPIV3.2": V32RequestUnmarshaller,
     }
     response_validators = {
         "OpenAPIV3.0": V30ResponseValidator,
         "OpenAPIV3.1": V31ResponseValidator,
+        "OpenAPIV3.2": V32ResponseValidator,
     }
     request_unmarshaller = request_unmarshallers[str(spec_version)]
     response_validator = response_validators[str(spec_version)]

--- a/pyramid_openapi3/tests/test_validation.py
+++ b/pyramid_openapi3/tests/test_validation.py
@@ -532,3 +532,9 @@ class TestImproperAPISpecValidation(RequestValidationBase):  # noqa: D101
                 }
             ],
         )
+
+
+class TestOpenAPI32Validation(TestRequestValidation):
+    """Re-runs every TestRequestValidation scenario against a 3.2.0 spec."""
+
+    openapi_spec = TestRequestValidation.openapi_spec.replace(b"3.1.0", b"3.2.0")


### PR DESCRIPTION
openapi-core already ships V32RequestUnmarshaller and V32ResponseValidator.
Wire into the version dispatch to make it work.

Resolves #306